### PR TITLE
Added 3 new lists and 2 software tools

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -39,9 +39,11 @@ One can use FilterLists in the following software tools. Software support of any
 *   [Adblock Plus](https://adblockplus.org/)
 *   [AdGuard](https://adguard.com/)
 *   [DNS66](https://github.com/julian-klode/dns66)
+*   [Hosts File Editor](https://github.com/scottlerch/HostsFileEditor)
 *   [Nano Adblocker](https://github.com/NanoAdblocker/NanoCore)
+*   [Personal Blocklist](https://chrome.google.com/webstore/detail/personal-blocklist-by-goo/nolijncfnkgaikbjbdaogikpmpbdcdef)
 *   [uBlock Origin](https://github.com/gorhill/uBlock)
-*   ...[Did we forget one?](https://github.com/collinbarrett/FilterLists/issues)
+*   …[Did we forget one?](https://github.com/collinbarrett/FilterLists/issues)
 
 ## Miscellany
 

--- a/data/FilterList.json
+++ b/data/FilterList.json
@@ -6339,7 +6339,7 @@
     "descriptionSourceUrl":
       "https://raw.githubusercontent.com/DandelionSprout/adfilt/master/NorwegianExtensionsForUBO%26Nano.txt",
     "discontinuedDate": null,
-    "donateUrl": "https://www.paypal.me/DandeeSprout",
+    "donateUrl": "https://sproutsluckycorner.wordpress.com/2017/11/14/my-work-and-contact-resume/#donations",
     "emailAddress": "imreeil42@gmail.com",
     "forumUrl": null,
     "homeUrl": "https://github.com/DandelionSprout/adfilt",
@@ -8282,5 +8282,65 @@
     "syntaxId": 4,
     "viewUrl":
       "https://raw.githubusercontent.com/DandelionSprout/adfilt/master/Dandelion%20Sprout's%20Website%20Stretcher.txt"
+  },
+  {
+    "id": 432,
+    "chatUrl": null,
+    "description":
+      "Do you feel that Friendship is Magic has overstayed its welcome? Here's a list that'll let you keep more of a distance to it.",
+    "descriptionSourceUrl": null,
+    "discontinuedDate": null,
+    "donateUrl": "https://sproutsluckycorner.wordpress.com/2017/11/14/my-work-and-contact-resume/#donations",
+    "emailAddress": "imreeil42@gmail.com",
+    "forumUrl": null,
+    "homeUrl": "https://github.com/DandelionSprout/adfilt",
+    "issuesUrl": "https://github.com/DandelionSprout/adfilt/issues",
+    "licenseId": 10,
+    "name": "Anti-FіМ List",
+    "policyUrl": null,
+    "publishedDate": null,
+    "submissionUrl": null,
+    "syntaxId": 3,
+    "viewUrl": "https://raw.githubusercontent.com/DandelionSprout/adfilt/master/Anti-F%D1%96%D0%9C%20List.txt"
+  },
+  {
+    "id": 433,
+    "chatUrl": null,
+    "description":
+      "Are you tired of being told by others what you should watch, specifically the hipsters that run around on IMDB? Here's a way to let you feel more peaceful with your truly own opinions.",
+    "descriptionSourceUrl": null,
+    "discontinuedDate": null,
+    "donateUrl": "https://sproutsluckycorner.wordpress.com/2017/11/14/my-work-and-contact-resume/#donations",
+    "emailAddress": "imreeil42@gmail.com",
+    "forumUrl": null,
+    "homeUrl": "https://github.com/DandelionSprout/adfilt",
+    "issuesUrl": "https://github.com/DandelionSprout/adfilt/issues",
+    "licenseId": 10,
+    "name": "Anti-IMDB List",
+    "policyUrl": null,
+    "publishedDate": null,
+    "submissionUrl": null,
+    "syntaxId": 4,
+    "viewUrl": "https://raw.githubusercontent.com/DandelionSprout/adfilt/master/Anti-IMDB%20List.txt"
+  },
+  {
+    "id": 434,
+    "chatUrl": null,
+    "description":
+      "Are you tired of having to turn off autoplay on YouTube every time you e.g. go to incognito mode? Are you worried of having to use specific extensions just for that purpose? Then this list is for you.",
+    "descriptionSourceUrl": null,
+    "discontinuedDate": null,
+    "donateUrl": "https://sproutsluckycorner.wordpress.com/2017/11/14/my-work-and-contact-resume/#donations",
+    "emailAddress": "imreeil42@gmail.com",
+    "forumUrl": null,
+    "homeUrl": "https://github.com/DandelionSprout/adfilt",
+    "issuesUrl": "https://github.com/DandelionSprout/adfilt/issues",
+    "licenseId": 10,
+    "name": "Stop Autoplay on YouTube",
+    "policyUrl": null,
+    "publishedDate": null,
+    "submissionUrl": null,
+    "syntaxId": 3,
+    "viewUrl": "https://raw.githubusercontent.com/DandelionSprout/adfilt/master/StopAutoplayOnYouTube.txt"
   }
 ]

--- a/data/FilterListMaintainer.json
+++ b/data/FilterListMaintainer.json
@@ -718,5 +718,21 @@
   {
     "filterListId": 430,
     "maintainerId": 22
+  },
+  {
+    "filterListId": 431,
+    "maintainerId": 22
+  },
+  {
+    "filterListId": 432,
+    "maintainerId": 22
+  },
+  {
+    "filterListId": 433,
+    "maintainerId": 22
+  },
+  {
+    "filterListId": 434,
+    "maintainerId": 22
   }
 ]


### PR DESCRIPTION
I sat on these first two lists of mine for some weeks, as I was concerned if they would come across to others as being somewhat hostile or not.

But as I feel that it's important for me to continue to show the world that adblockers can be used for so many more things than to block ads, and to also disprove all those editorials on techsites that seem to think of adblockers as an economic scam, I've added them here after all, in addition to a list that aims to prevent autoplay on YouTube.