### PR TITLE
Upgraded supported list links to HTTPS

### DIFF
--- a/data/FilterList.json
+++ b/data/FilterList.json
@@ -603,7 +603,7 @@
     "publishedDate": null,
     "submissionUrl": null,
     "syntaxId": null,
-    "viewUrl": "http://www.niecko.pl/adblock/adblock.txt"
+    "viewUrl": "https://www.niecko.pl/adblock/adblock.txt"
   },
   {
     "id": 32,
@@ -1201,7 +1201,7 @@
     "publishedDate": null,
     "submissionUrl": null,
     "syntaxId": null,
-    "viewUrl": "http://qme.mydns.jp/data/AdblockV2.txt"
+    "viewUrl": "https://qme.mydns.jp/data/AdblockV2.txt"
   },
   {
     "id": 63,
@@ -1221,7 +1221,7 @@
     "publishedDate": null,
     "submissionUrl": null,
     "syntaxId": null,
-    "viewUrl": "http://qme.mydns.jp/data/Adblock.txt"
+    "viewUrl": "https://qme.mydns.jp/data/Adblock.txt"
   },
   {
     "id": 64,
@@ -1279,7 +1279,7 @@
     "publishedDate": null,
     "submissionUrl": null,
     "syntaxId": null,
-    "viewUrl": "http://www.jabcreations.com/downloads/adblock-filters.php"
+    "viewUrl": "https://www.jabcreations.com/downloads/adblock-filters.php"
   },
   {
     "id": 67,
@@ -1336,7 +1336,7 @@
     "publishedDate": null,
     "submissionUrl": null,
     "syntaxId": null,
-    "viewUrl": "http://adblock.gardar.net/is.abp.txt"
+    "viewUrl": "https://adblock.gardar.net/is.abp.txt"
   },
   {
     "id": 70,
@@ -2221,7 +2221,7 @@
     "publishedDate": null,
     "submissionUrl": null,
     "syntaxId": null,
-    "viewUrl": "http://hostsfile.mine.nu/hosts0.txt"
+    "viewUrl": "https://hostsfile.mine.nu/hosts0.txt"
   },
   {
     "id": 116,
@@ -2601,7 +2601,7 @@
     "publishedDate": null,
     "submissionUrl": null,
     "syntaxId": null,
-    "viewUrl": "http://hostsfile.mine.nu/downloads/adblock.txt"
+    "viewUrl": "https://hostsfile.mine.nu/downloads/adblock.txt"
   },
   {
     "id": 136,
@@ -2928,7 +2928,7 @@
     "publishedDate": null,
     "submissionUrl": null,
     "syntaxId": null,
-    "viewUrl": "http://pastebin.com/raw/r9a5WrZa"
+    "viewUrl": "https://pastebin.com/raw/r9a5WrZa"
   },
   {
     "id": 153,
@@ -2947,7 +2947,7 @@
     "publishedDate": null,
     "submissionUrl": null,
     "syntaxId": null,
-    "viewUrl": "http://adb.juvander.net/Finland_adb_antisocial.txt"
+    "viewUrl": "https://adb.juvander.net/Finland_adb_antisocial.txt"
   },
   {
     "id": 154,
@@ -3459,7 +3459,7 @@
     "publishedDate": null,
     "submissionUrl": null,
     "syntaxId": null,
-    "viewUrl": "http://www.hostsfile.org/Downloads/hosts.txt"
+    "viewUrl": "https://www.hostsfile.org/Downloads/hosts.txt"
   },
   {
     "id": 180,
@@ -4222,7 +4222,7 @@
     "publishedDate": null,
     "submissionUrl": null,
     "syntaxId": null,
-    "viewUrl": "http://adb.juvander.net/Finland_adb.txt"
+    "viewUrl": "https://adb.juvander.net/Finland_adb.txt"
   },
   {
     "id": 219,
@@ -4241,7 +4241,7 @@
     "publishedDate": null,
     "submissionUrl": null,
     "syntaxId": null,
-    "viewUrl": "http://blogram.net/wp-content/uploads/easylist3.txt"
+    "viewUrl": "https://blogram.net/wp-content/uploads/easylist3.txt"
   },
   {
     "id": 220,
@@ -4452,7 +4452,7 @@
     "publishedDate": null,
     "submissionUrl": null,
     "syntaxId": null,
-    "viewUrl": "http://blogram.net/wp-content/uploads/easylist2.txt"
+    "viewUrl": "https://blogram.net/wp-content/uploads/easylist2.txt"
   },
   {
     "id": 231,
@@ -4471,7 +4471,7 @@
     "publishedDate": null,
     "submissionUrl": null,
     "syntaxId": null,
-    "viewUrl": "http://blogram.net/wp-content/uploads/easylist1.txt"
+    "viewUrl": "https://blogram.net/wp-content/uploads/easylist1.txt"
   },
   {
     "id": 232,
@@ -4586,7 +4586,7 @@
     "publishedDate": null,
     "submissionUrl": null,
     "syntaxId": null,
-    "viewUrl": "http://adblock.ee/list.php"
+    "viewUrl": "https://adblock.ee/list.php"
   },
   {
     "id": 238,
@@ -5166,7 +5166,7 @@
     "publishedDate": null,
     "submissionUrl": null,
     "syntaxId": null,
-    "viewUrl": "http://margevicius.lt/easylistlithuania.txt"
+    "viewUrl": "https://margevicius.lt/easylistlithuania.txt"
   },
   {
     "id": 268,
@@ -5224,7 +5224,7 @@
     "publishedDate": null,
     "submissionUrl": null,
     "syntaxId": null,
-    "viewUrl": "http://mirror1.malwaredomains.com/files/bulk_registrars.txt"
+    "viewUrl": "https://mirror1.malwaredomains.com/files/bulk_registrars.txt"
   },
   {
     "id": 271,
@@ -5339,7 +5339,7 @@
     "publishedDate": null,
     "submissionUrl": null,
     "syntaxId": null,
-    "viewUrl": "http://someonewhocares.org/hosts/zero/hosts"
+    "viewUrl": "https://someonewhocares.org/hosts/zero/hosts"
   },
   {
     "id": 277,
@@ -5513,7 +5513,7 @@
     "publishedDate": null,
     "submissionUrl": null,
     "syntaxId": null,
-    "viewUrl": "http://mirror1.malwaredomains.com/files/dynamic_dns.txt"
+    "viewUrl": "https://mirror1.malwaredomains.com/files/dynamic_dns.txt"
   },
   {
     "id": 286,
@@ -5532,7 +5532,7 @@
     "publishedDate": null,
     "submissionUrl": null,
     "syntaxId": null,
-    "viewUrl": "http://mirror1.malwaredomains.com/files/freewebhosts.txt"
+    "viewUrl": "https://mirror1.malwaredomains.com/files/freewebhosts.txt"
   },
   {
     "id": 287,
@@ -5551,7 +5551,7 @@
     "publishedDate": null,
     "submissionUrl": null,
     "syntaxId": null,
-    "viewUrl": "http://mirror1.malwaredomains.com/files/justdomains"
+    "viewUrl": "https://mirror1.malwaredomains.com/files/justdomains"
   },
   {
     "id": 288,
@@ -5570,7 +5570,7 @@
     "publishedDate": null,
     "submissionUrl": null,
     "syntaxId": null,
-    "viewUrl": "http://mirror1.malwaredomains.com/files/immortal_domains.txt"
+    "viewUrl": "https://mirror1.malwaredomains.com/files/immortal_domains.txt"
   },
   {
     "id": 289,
@@ -5726,7 +5726,7 @@
     "publishedDate": null,
     "submissionUrl": null,
     "syntaxId": null,
-    "viewUrl": "http://blogram.net/wp-content/uploads/easylist4.txt"
+    "viewUrl": "https://blogram.net/wp-content/uploads/easylist4.txt"
   },
   {
     "id": 297,
@@ -5842,7 +5842,7 @@
     "publishedDate": null,
     "submissionUrl": null,
     "syntaxId": null,
-    "viewUrl": "http://feeds.dshield.org/block.txt"
+    "viewUrl": "https://feeds.dshield.org/block.txt"
   },
   {
     "id": 303,
@@ -5861,7 +5861,7 @@
     "publishedDate": null,
     "submissionUrl": null,
     "syntaxId": null,
-    "viewUrl": "http://mirror1.malwaredomains.com/files/url_shorteners.txt"
+    "viewUrl": "https://mirror1.malwaredomains.com/files/url_shorteners.txt"
   },
   {
     "id": 304,
@@ -5975,7 +5975,7 @@
     "publishedDate": null,
     "submissionUrl": null,
     "syntaxId": 1,
-    "viewUrl": "http://1hosts.cf/"
+    "viewUrl": "https://1hosts.cf/"
   },
   {
     "id": 310,
@@ -5994,7 +5994,7 @@
     "publishedDate": null,
     "submissionUrl": null,
     "syntaxId": 2,
-    "viewUrl": "http://1hosts.cf/addon/"
+    "viewUrl": "https://1hosts.cf/addon/"
   },
   {
     "id": 311,

--- a/data/FilterList.json
+++ b/data/FilterList.json
@@ -1764,25 +1764,6 @@
     "viewUrl": "https://raw.githubusercontent.com/uBlockOrigin/uAssets/master/filters/badware.txt"
   },
   {
-    "id": 92,
-    "chatUrl": null,
-    "description": "Ad servers list to block ads on Turkish websites (for use with hosts files).",
-    "descriptionSourceUrl": "https://github.com/bkrucarci/turk-adlist/blob/master/README.md",
-    "discontinuedDate": null,
-    "donateUrl": null,
-    "emailAddress": null,
-    "forumUrl": null,
-    "homeUrl": "https://github.com/bkrucarci/turk-adlist",
-    "issuesUrl": "https://github.com/bkrucarci/turk-adlist/issues",
-    "licenseId": 6,
-    "name": "Turk-adlist",
-    "policyUrl": null,
-    "publishedDate": null,
-    "submissionUrl": null,
-    "syntaxId": 1,
-    "viewUrl": "https://raw.githubusercontent.com/bkrucarci/turk-adlist/master/hosts"
-  },
-  {
     "id": 93,
     "chatUrl": null,
     "description": "Extending and consolidating hosts files from a variety of sources",


### PR DESCRIPTION
Having stumbled across #335, I decided to see how many of the HTTP list links that actually did support HTTPS after all, by pasting `##a[href*=https]` into Nano Adblocker's element selector, taking note of the subscription links that *weren't* highlighted, and then visiting them with [the **Smart HTTPS** extension](https://github.com/ilGur1132/Smart-HTTPS) turned on.

My findings were as follows:
✓ 1hosts
✓ 1hosts Addon
✓ Adblock List for Finland
✓ BadHosts
✓ BLOGRAM *
✓ Dan Pollock's Hosts
✓ DNS-BH *
✓ DShield.org (…)
✓ EasyList Lithuania
✓ Eesti Custom Sites Filter
✓ Finnish AntiSocial
✓ Firime (FED)
✓ Icelandic ABP List
✓ JAB Creations' (…)
✓ Japanese Site Adblock Filter *
✓ PLgeneral
✓ The Hosts File Project *
X Adblock Filters by Gurud.ee
X Airelle's *
X Ayucat Powerful List
X CAMELEON Hosts
X Czech Filters for AdBlock
X Facebook Privacy List
X GNU Blacklist
X Malware URLs
X MVPS HOSTS
X Phishing Bad Sites
X Rickroll Blacklist
X RU AdList [Old]
X SA-Blacklist
X Tofu Filter
X VXVault

(…) is a generic shortener, while * is a wildcard for every list name that start with the prior words.

So I've attempted to turn the links to HTTPS-supported sites into HTTPS in this pull request.