### PR TITLE
Removed the G&J lists, whose domain seems to have been hijacked

### DIFF
--- a/data/FilterList.json
+++ b/data/FilterList.json
@@ -2641,25 +2641,6 @@
     "viewUrl": "https://shopping.mileageplus.com/adBlockWhitelist.php"
   },
   {
-    "id": 142,
-    "chatUrl": null,
-    "description": "Block ads with AdBlock filter.",
-    "descriptionSourceUrl": "http://adblock.gjtech.net/?format=unix-hosts",
-    "discontinuedDate": null,
-    "donateUrl": null,
-    "emailAddress": null,
-    "forumUrl": null,
-    "homeUrl": "https://www.gjtech.net/",
-    "issuesUrl": null,
-    "licenseId": 5,
-    "name": "G&J AdBlock",
-    "policyUrl": null,
-    "publishedDate": null,
-    "submissionUrl": null,
-    "syntaxId": null,
-    "viewUrl": "http://adblock.gjtech.net/?format=unix-hosts"
-  },
-  {
     "id": 143,
     "chatUrl": null,
     "description": "Whitelists the trackers on the Southwest Airlines shopping portal so that rewards can be credited.",


### PR DESCRIPTION
Having decided to randomly test out that list's URLs, I see that their domain (`gjtech.net`) has been taken over for shady reasons, and that any links to them should be removed **immediately!**

I was only brave enough to check it out twice. On the first occasion it tried to make me download a (practically guaranteedly fake) Chrome extension, and on the second occasion it led me to `lostrabbitmedia.com`, which is said to be a fake search engine.

If it's not removed automatically upon the approval of this pull, then that too should be taken care of by you (Collin) as soon as possible. I'd even advocate removing it from the older APIs of FilterLists.com as well, unless you feel otherwise.