### PR TITLE
Stresstesting the tagging system or something

### DIFF
--- a/data/FilterListTag.json
+++ b/data/FilterListTag.json
@@ -60,6 +60,38 @@
     "tagId": 9
   },
   {
+    "filterListId": 103,
+    "tagId": 1
+  },
+  {
+    "filterListId": 103,
+    "tagId": 2
+  },
+  {
+    "filterListId": 103,
+    "tagId": 3
+  },
+  {
+    "filterListId": 103,
+    "tagId": 4
+  },
+  {
+    "filterListId": 103,
+    "tagId": 6
+  },
+  {
+    "filterListId": 103,
+    "tagId": 7
+  },
+  {
+    "filterListId": 103,
+    "tagId": 11
+  },
+  {
+    "filterListId": 103,
+    "tagId": 15
+  },
+  {
     "filterListId": 134,
     "tagId": 9
   },


### PR DESCRIPTION
Now that I see that tags can be properly stacked on top of each other on FilterLists.com, I think it's time to stresstest it, with what seems to be most tag-warranting list on the site: `Unified Hosts + Fakenews + Gambling + Porn + Social`