### PR TITLE
Did some questionable coding of my own

### DIFF
--- a/src/FilterLists.Web/ClientApp/modules/home/components/linkButtons/SubscribeButton.tsx
+++ b/src/FilterLists.Web/ClientApp/modules/home/components/linkButtons/SubscribeButton.tsx
@@ -19,12 +19,28 @@ export const SubscribeButton = (props: IProps) => {
         titlePrefix = "";
     }
 
+    if (props.syntaxId("10") ) {
+    const hrefTitle = `&amp;title=${encodeURIComponent(props.name)}`;
+    const href = `javascript:window.external.msAddTrackingProtectionList('${encodeURIComponent(props.url)}','${hrefTitle}')`;
+    const title =
+        `${titlePrefix}Subscribe to ${props.name
+            } with Internet Explorer's Tracking Protection List feature.`;
+    
+    } if (props.syntaxId("18") ) {
+    const hrefTitle = `&amp;title=${encodeURIComponent(props.name)}`;
+    const href = `x-littlesnitch:subscribe-rules?url=${encodeURIComponent(props.url)}`;
+    const title =
+        `${titlePrefix}Subscribe to ${props.name
+            } with Little Snitch's list subscription feature.`;
+    
+    } else {
     const hrefTitle = `&amp;title=${encodeURIComponent(props.name)}`;
     const href = `abp:subscribe?location=${encodeURIComponent(props.url)}${hrefTitle}`;
     const title =
         `${titlePrefix}Subscribe to ${props.name
             } with a browser extension supporting the \"abp:\" protocol (e.g. uBlock Origin, Adblock Plus).`;
-
+    }
+        
     return props.url
                ? <LinkButton href={href}
                              title={title}


### PR DESCRIPTION
I know that #289 was considered to be wontfix, but there's two new developments that have led me to de facto re-open the matter through this pull:

1) I've stumbled across some 15-ish TPL lists on a few places (such as on [Jansal](http://jansal.net/tpl/) and [Fanboy](https://fanboy.co.nz/ie.html)), which means there's a fair few more lists out there than just the 2 that were on FilterLists.com at the time the matter was first discussed. It'd also be almost worthless to add all those new TPL lists if it wasn't possible to make proper use of them.
2) I've become aware through https://pgl.yoyo.org/adservers/news.php?#littlesnitch-rule-group-subscriptions that Little Snitch also has a subscription link system of its own, meaning that it'd be nice to accomodate to this tool's link system and to potential tools that were to be discovered in the future.

Me and coding languages are not the best of buddies, so who knows how much I've messed things up here. But I felt it was worth a try.
