### PR TITLE
Thursday morning pull

### DIFF
--- a/data/FilterList.json
+++ b/data/FilterList.json
@@ -8310,7 +8310,7 @@
     "viewUrl": "https://easylist-msie.adblockplus.org/easylistspanish+easylist.tpl"
   },
   {
-      "id": 801,
+     "id": 801,
       "description": "This is a Macedonian list",
       "descriptionSourceUrl": "https://raw.githubusercontent.com/DandelionSprout/adfilt/master/AncientLibrary/ABP%20Macedonian%20List.txt",
       "discontinuedDate": "2011-05-11T00:00:00",
@@ -8379,7 +8379,7 @@
     },
     {
       "id": 807,
-      "description": "This is a cosmetic filter for the uBlock Origin extension (with adblock support) to automatically filter all the pro-5-Star comments and the \"anti-information\" pages they share with sensationalistic headlines.",
+      "description": "This is a cosmetic filter for the uBlock Origin extension (with adblock support) to automatically filter all the pro-5-Star comments and the 'anti-information' pages they share with sensationalistic headlines.",
       "descriptionSourceUrl": "https://github.com/luigimannoni/m5s-ublock-filter#cosa-%C3%A9",
       "homeUrl": "https://github.com/luigimannoni/m5s-ublock-filter",
       "issuesUrl": "https://github.com/luigimannoni/m5s-ublock-filter/issues",
@@ -8402,4 +8402,4 @@
       "syntaxId": 3,
       "viewUrl": "http://www.verzijlbergh.com/adblock/nlblock.txt"
     }
-]
+   ]

--- a/data/FilterList.json
+++ b/data/FilterList.json
@@ -1921,7 +1921,9 @@
     "licenseId": 5,
     "name": "Ayucat Powerful List",
     "syntaxId": 3,
-    "viewUrl": "http://git.sourceforge.jp/view?p=ayucat-list/ayucat-list.git;a=blob_plain;f=ayucat-list.txt;hb=b254c74c132832a3ade7b9d42c2ef8d3dd59fdb9"
+    "viewUrl": "http://git.sourceforge.jp/view?p=ayucat-list/ayucat-list.git;a=blob_plain;f=ayucat-list.txt;hb=b254c74c132832a3ade7b9d42c2ef8d3dd59fdb9",
+    "viewUrlMirror1": "https://raw.githubusercontent.com/DandelionSprout/adfilt/master/AncientLibrary/Ayucat%20Powerful%20List.txt",
+    "viewUrlMirror2": "https://repo.or.cz/FilterMirrorRepo.git/blob_plain/refs/heads/master:/AncientLibrary/Ayucat%20Powerful%20List.txt"
   },
   {
     "id": 182,
@@ -2528,7 +2530,9 @@
     "licenseId": 5,
     "name": "Facebook Privacy List",
     "syntaxId": 3,
-    "viewUrl": "http://www.squirrelconspiracy.net/abp/facebook-privacy-list.txt"
+    "viewUrl": "http://www.squirrelconspiracy.net/abp/facebook-privacy-list.txt",
+    "viewUrlMirror1": "https://raw.githubusercontent.com/DandelionSprout/adfilt/master/AncientLibrary/Facebook%20Privacy%20List.txt",
+    "viewUrlMirror2": "https://repo.or.cz/FilterMirrorRepo.git/blob_plain/refs/heads/master:/AncientLibrary/Facebook%20Privacy%20List.txt"
   },
   {
     "id": 235,
@@ -3016,7 +3020,9 @@
     "licenseId": 5,
     "name": "Czech Filters for AdBlock",
     "syntaxId": 3,
-    "viewUrl": "http://adblock.dajbych.net/adblock.txt"
+    "viewUrl": "http://adblock.dajbych.net/adblock.txt",
+    "viewUrlMirror1": "https://raw.githubusercontent.com/DandelionSprout/adfilt/master/AncientLibrary/Czech%20Filters%20for%20Adblock%20Plus",
+    "viewUrlMirror2": "https://repo.or.cz/FilterMirrorRepo.git/blob_plain/refs/heads/master:/AncientLibrary/Czech%20Filters%20for%20Adblock%20Plus"
   },
   {
     "id": 278,
@@ -8302,5 +8308,98 @@
     "name": "EasyList Spanish + EasyList (TPL)",
     "syntaxId": 10,
     "viewUrl": "https://easylist-msie.adblockplus.org/easylistspanish+easylist.tpl"
-  }
+  },
+  {
+      "id": 801,
+      "description": "This is a Macedonian list",
+      "descriptionSourceUrl": "https://raw.githubusercontent.com/DandelionSprout/adfilt/master/AncientLibrary/ABP%20Macedonian%20List.txt",
+      "discontinuedDate": "2011-05-11T00:00:00",
+      "homeUrl": "https://github.com/DandelionSprout/adfilt/tree/master/AncientLibrary",
+      "issuesUrl": "https://github.com/DandelionSprout/adfilt/issues",
+      "name": "ABP Macedonian List",
+      "syntaxId": 3,
+      "viewUrl": "https://raw.githubusercontent.com/DandelionSprout/adfilt/master/AncientLibrary/ABP%20Macedonian%20List.txt"
+    },
+    {
+      "id": 802,
+      "description": "Algerian filters for Adblock Plus",
+      "descriptionSourceUrl": "https://raw.githubusercontent.com/DandelionSprout/adfilt/master/AncientLibrary/Liste%20DZ.txt",
+      "discontinuedDate": "2011-05-25T00:00:00",
+      "homeUrl": "https://github.com/DandelionSprout/adfilt/tree/master/AncientLibrary",
+      "issuesUrl": "https://github.com/DandelionSprout/adfilt/issues",
+      "licenseId": 6,
+      "name": "Liste DZ",
+      "syntaxId": 3,
+      "viewUrl": "https://raw.githubusercontent.com/DandelionSprout/adfilt/master/AncientLibrary/Liste%20DZ.txt",
+      "viewUrlMirror1": "https://repo.or.cz/FilterMirrorRepo.git/blob_plain/refs/heads/master:/AncientLibrary/Liste%20DZ.txt"
+    },
+    {
+      "id": 803,
+      "description": "General icelandic ad and blocking subscription",
+      "descriptionSourceUrl": "https://raw.githubusercontent.com/DandelionSprout/adfilt/master/AncientLibrary/Snaevar87's%20Icelandic%20filter.txt",
+      "discontinuedDate": "2014-03-11T00:00:00",
+      "homeUrl": "https://github.com/DandelionSprout/adfilt/tree/master/AncientLibrary",
+      "issuesUrl": "https://github.com/DandelionSprout/adfilt/issues",
+      "name": "Snaevar87's Icelandic filter",
+      "syntaxId": 3,
+      "viewUrl": "https://raw.githubusercontent.com/DandelionSprout/adfilt/master/AncientLibrary/Snaevar87's%20Icelandic%20filter.txt",
+      "viewUrlMirror1": "https://repo.or.cz/FilterMirrorRepo.git/blob_plain/refs/heads/master:/AncientLibrary/Snaevar87%27s%20Icelandic%20filter.txt"
+    },
+    {
+      "id": 804,
+      "descriptionSourceUrl": "https://raw.githubusercontent.com/DandelionSprout/adfilt/master/AncientLibrary/TamilFriends%20List.txt",
+      "discontinuedDate": "2010-07-30T00:00:00",
+      "emailAddress": "tamilfriendslist@gmail.com",
+      "homeUrl": "https://github.com/DandelionSprout/adfilt/tree/master/AncientLibrary",
+      "issuesUrl": "https://github.com/DandelionSprout/adfilt/issues",
+      "licenseId": 16,
+      "name": "TamilFriends List",
+      "syntaxId": 3,
+      "viewUrl": "https://raw.githubusercontent.com/DandelionSprout/adfilt/master/AncientLibrary/TamilFriends%20List.txt",
+      "viewUrlMirror1": "https://repo.or.cz/FilterMirrorRepo.git/blob_plain/refs/heads/master:/AncientLibrary/TamilFriends%20List.txt"
+    },
+    {
+      "id": 805,
+      "description": "A combined version of the filterlist RU AdList against advertising, and an experimental list of cosmetic CSS style fixes. At the moment it only works normally in uBlock Origin.",
+      "descriptionSourceUrl": "https://easylist-downloads.adblockplus.org/advblock+cssfixes.txt",
+      "forumUrl": "https://forums.lanik.us/viewforum.php?f=102",
+      "homeUrl": "https://forums.lanik.us/viewforum.php?f=102",
+      "name": "RU AdList + CSS Fixes",
+      "syntaxId": 4,
+      "viewUrl": "https://easylist-downloads.adblockplus.org/advblock+cssfixes.txt"
+    },
+    {
+      "id": 806,
+      "emailAddress": "easylist.portuguese@gmail.com",
+      "homeUrl": "https://easylist.to/",
+      "licenseId": 4,
+      "name": "EasyList Portuguese",
+      "syntaxId": 3,
+      "viewUrl": "https://easylist-downloads.adblockplus.org/easylistportuguese.txt"
+    },
+    {
+      "id": 807,
+      "description": "This is a cosmetic filter for the uBlock Origin extension (with adblock support) to automatically filter all the pro-5-Star comments and the \"anti-information\" pages they share with sensationalistic headlines.",
+      "descriptionSourceUrl": "https://github.com/luigimannoni/m5s-ublock-filter#cosa-%C3%A9",
+      "homeUrl": "https://github.com/luigimannoni/m5s-ublock-filter",
+      "issuesUrl": "https://github.com/luigimannoni/m5s-ublock-filter/issues",
+      "name": "M5S uBlock Filter",
+      "syntaxId": 4,
+      "viewUrl": "https://raw.githubusercontent.com/luigimannoni/m5s-ublock-filter/master/filter-list.txt"
+    },
+    {
+      "id": 808,
+      "homeUrl": "https://ajnasz.hu/adblock",
+      "name": "ajnasz's list",
+      "syntaxId": 3,
+      "viewUrl": "https://ajnasz.hu/adblock/recent"
+    },
+    {
+      "id": 809,
+      "discontinuedDate": "2014-12-15T00:00:00",
+      "homeUrl": "https://www.ergensin.nl/",
+      "name": "NLblock",
+      "syntaxId": 3,
+      "viewUrl": "http://www.verzijlbergh.com/adblock/nlblock.txt"
+    }
 ]

--- a/data/FilterListLanguage.json
+++ b/data/FilterListLanguage.json
@@ -997,6 +997,42 @@
   },
   {
     "filterListId": 800,
-    "languageId": 59
+    "languageId": 79
+  },
+  {
+    "filterListId": 801,
+    "languageId": 29
+  },
+  {
+    "filterListId": 802,
+    "languageId": 122
+  },
+  {
+    "filterListId": 803,
+    "languageId": 160
+  },
+  {
+    "filterListId": 804,
+    "languageId": 84
+  },
+  {
+    "filterListId": 805,
+    "languageId": 18
+  },
+  {
+    "filterListId": 806,
+    "languageId": 13
+  },
+  {
+    "filterListId": 807,
+    "languageId": 159
+  },
+  {
+    "filterListId": 808,
+    "languageId": 177
+  },
+  {
+    "filterListId": 809,
+    "languageId": 108
   }
 ]


### PR DESCRIPTION
The thought process behind 801-804 deserves an explanation:

I found myself looking through https://hg.adblockplus.org/subscriptionlist/file somehow, and saw some lists there that I had never seen before, including Macedonian and Tamil lists. I let out a sigh when I saw that several of them were hosted on Google Code, a host site that I thought had shut down completely in 2014. However, while testing a bit around with Archive.org and being redirected around a few times, I discovered that they were still hosted on the archive version of Google Code... with the code still intact! 🕺🎉

But the code was only available as part of ZIP files. I thought about it for some minutes, before realising *"Wait, why don't I host them myself?"*. And so it happened: https://github.com/DandelionSprout/adfilt/tree/master/AncientLibrary

PS: One day I'll get around to adding tags to the more than 100 recentmost added lists, but I've recently prioritised to simply add lists instead. 🐹 
