### PR TITLE
Tuesday night pull

### DIFF
--- a/data/FilterList.json
+++ b/data/FilterList.json
@@ -4509,13 +4509,13 @@
   },
   {
     "id": 389,
-    "description": "Here's how this list works. This is a categorised list of URLs that clot up Google search results. The list is designed for use with Personal Blocklist (and its Import function) for Google Search and Google Chrome users, in such a way that it removes search results for the URLs from your Google searches. If any other URL-based search-result-blockers for other search engines (incl. for Google Image Search) and browsers exist out there, feel free to tell me about them. The list is VERY subjective, so quite a few of you may NOT want to block the results for ALL of these URLs. In that case, simply pick whichever ones from this buffet that you want to block, and paste them into Personal Blocklist. While this list is technically possible to add to adblocker tools, it'd be a very bad idea to do so, since you wouldn't have any control over which URLs you'll be able to block outright or not.",
+    "description": "Here's how this list works. This is a categorised list of URLs that clot up Google search results. The list is designed for use with Google Hit Hider by Domain (and its Import function) for Google Search and Google Chrome users, in such a way that it removes search results for the URLs from your Google searches. If any other URL-based search-result-blockers for other search engines (incl. for Google Image Search) and browsers exist out there, feel free to tell me about them. The list is VERY subjective, so quite a few of you may NOT want to block the results for ALL of these URLs. In that case, simply pick whichever ones from this buffet that you want to block, and paste them into Google Hit Hider by Domain. While this list is technically possible to add to adblocker tools, it'd be a very bad idea to do so, since you wouldn't have any control over which URLs you'll be able to block outright or not.",
     "donateUrl": "https://sproutsluckycorner.wordpress.com/2017/11/14/my-work-and-contact-resume/#donations",
     "emailAddress": "imreeil42@gmail.com",
     "homeUrl": "https://github.com/DandelionSprout/adfilt",
     "issuesUrl": "https://github.com/DandelionSprout/adfilt/issues",
     "licenseId": 10,
-    "name": "Dandelion Sprout's list for Personal Blocklist",
+    "name": "Dandelion Sprout's list for Google Hit Hider by Domain",
     "syntaxId": 2,
     "viewUrl": "https://raw.githubusercontent.com/DandelionSprout/adfilt/master/List%20for%20Chrome%20Personal%20Blocklist",
     "viewUrlMirror1": "https://repo.or.cz/FilterMirrorRepo.git/blob_plain/refs/heads/master:/List%20for%20Chrome%20Personal%20Blocklist"
@@ -4550,7 +4550,7 @@
   },
   {
     "id": 392,
-    "description": "Intends to make it easier to browse various websites without being forced by various nag-windows to log in. At the time of writing (15th of May 2018) it chiefly supports Pinterest, Facebook and Pixiv.",
+    "description": "Intends to make it easier to browse various websites without being forced by various nag-windows to log in.",
     "donateUrl": "https://sproutsluckycorner.wordpress.com/2017/11/14/my-work-and-contact-resume/#donations",
     "emailAddress": "imreeil42@gmail.com",
     "homeUrl": "https://github.com/DandelionSprout/adfilt",

--- a/data/FilterList.json
+++ b/data/FilterList.json
@@ -9328,5 +9328,45 @@
     "name": "sipp11's Thai Ad Filters",
     "syntaxId": 3,
     "viewUrl": "https://github.com/sipp11/th_ad_filters/raw/master/th_list.txt"
+  },
+  {
+    "id": 848,
+    "description": "Makes things a bit more tidy when watching things on Twitch.",
+    "donateUrl": "https://sproutsluckycorner.wordpress.com/2017/11/14/my-work-and-contact-resume/#donations",
+    "emailAddress": "imreeil42@gmail.com",
+    "homeUrl": "https://github.com/DandelionSprout/adfilt",
+    "issuesUrl": "https://github.com/DandelionSprout/adfilt/issues",
+    "licenseId": 10,
+    "name": "Twitch: Pure Viewing Experience",
+    "syntaxId": 3,
+    "viewUrl": "https://raw.githubusercontent.com/DandelionSprout/adfilt/master/TwitchPureViewingExperience.txt",
+    "viewUrlMirror1": "https://repo.or.cz/FilterMirrorRepo.git/blob_plain/refs/heads/master:/TwitchPureViewingExperience.txt"
+  },
+  {
+    "id": 849,
+    "description": "This list aims to prevent low-quality (or even illegal) forks of more popular adblockers, adblockers that add unnecessary tracking, as well as links to dead filterlists. Currently this list only fully works with AdGuard's paid desktop version, as most other adblockers will refuse to function on a browser's own extension store.",
+    "donateUrl": "https://sproutsluckycorner.wordpress.com/2017/11/14/my-work-and-contact-resume/#donations",
+    "emailAddress": "imreeil42@gmail.com",
+    "homeUrl": "https://github.com/DandelionSprout/adfilt",
+    "issuesUrl": "https://github.com/DandelionSprout/adfilt/issues",
+    "licenseId": 10,
+    "name": "List Against Fake or Inoptimal Adblockers",
+    "syntaxId": 3,
+    "viewUrl": "https://raw.githubusercontent.com/DandelionSprout/adfilt/master/ListAgainstFakeOrInoptimalAdblockers.txt",
+    "viewUrlMirror1": "https://repo.or.cz/FilterMirrorRepo.git/blob_plain/refs/heads/master:/ListAgainstFakeOrInoptimalAdblockers.txt"
+  },
+  {
+    "id": 850,
+    "description": "Pixiv is an East Asian artsite, whose average art quality wipes the floor with DeviantArt. It also allows porn of many types. Pressure on \"many\". So say that you're looking for imagery of consensual and pleasurable sex, and then you stumble across a crying Daniel Tiger with a corset being strapped to a bench in a diaper? Now such scenarios won't occur nearly as often as they did before!",
+    "descriptionSourceUrl": "https://raw.githubusercontent.com/DandelionSprout/adfilt/master/AntiAbusePorn.txt",
+    "donateUrl": "https://sproutsluckycorner.wordpress.com/2017/11/14/my-work-and-contact-resume/#donations",
+    "emailAddress": "imreeil42@gmail.com",
+    "homeUrl": "https://github.com/DandelionSprout/adfilt",
+    "issuesUrl": "https://github.com/DandelionSprout/adfilt/issues",
+    "licenseId": 10,
+    "name": "Anti-'Abuse porn' list for Pixiv",
+    "syntaxId": 3,
+    "viewUrl": "https://raw.githubusercontent.com/DandelionSprout/adfilt/master/AntiAbusePorn.txt",
+    "viewUrlMirror1": "https://repo.or.cz/FilterMirrorRepo.git/blob_plain/refs/heads/master:/AntiAbusePorn.txt"
   }
 ]

--- a/data/FilterListMaintainer.json
+++ b/data/FilterListMaintainer.json
@@ -628,6 +628,18 @@
     "maintainerId": 22
   },
   {
+    "filterListId": 848,
+    "maintainerId": 22
+  },
+  {
+    "filterListId": 849,
+    "maintainerId": 22
+  },
+  {
+    "filterListId": 850,
+    "maintainerId": 22
+  },
+  {
     "filterListId": 21,
     "maintainerId": 23
   },

--- a/data/FilterListTag.json
+++ b/data/FilterListTag.json
@@ -3962,5 +3962,25 @@
   {
     "filterListId": 847,
     "tagId": 2
+  },
+  {
+    "filterListId": 848,
+    "tagId": 9
+  },
+  {
+    "filterListId": 849,
+    "tagId": 3
+  },
+  {
+    "filterListId": 849,
+    "tagId": 6
+  },
+  {
+    "filterListId": 850,
+    "tagId": 11
+  },
+  {
+    "filterListId": 850,
+    "tagId": 15
   }
 ]

--- a/data/Software.json
+++ b/data/Software.json
@@ -50,10 +50,10 @@
   },
   {
     "id": 8,
-    "downloadUrl": "https://chrome.google.com/webstore/detail/personal-blocklist-by-goo/nolijncfnkgaikbjbdaogikpmpbdcdef",
-    "homeUrl": "https://chrome.google.com/webstore/detail/personal-blocklist-by-goo/nolijncfnkgaikbjbdaogikpmpbdcdef",
+    "downloadUrl": "https://addons.mozilla.org/firefox/addon/personal-blocklist/",
+    "homeUrl": "https://addons.mozilla.org/firefox/addon/personal-blocklist/",
     "isAbpSubscribable": false,
-    "name": "Personal Blocklist"
+    "name": "Personal Blocklist for Firefox"
   },
   {
     "id": 10,


### PR DESCRIPTION
This pull deals with two things:

• I've been doing some autumn cleaning on my personal-purposes-only list, and have begun to spin off some categories from it into lists that are more suitable for public use.
• The Chrome versions of Personal Blocklist no longer works. I've therefore made a few changes to coach Chrome users onto *Google Hit Hider by Domain*, which still works.