### PR TITLE
Removing non-Origin uBlock from the software list

### DIFF
--- a/data/Software.json
+++ b/data/Software.json
@@ -91,13 +91,6 @@
     "name": "Pi-hole"
   },
   {
-    "id": 15,
-    "downloadUrl": "https://www.ublock.org/",
-    "homeUrl": "https://www.ublock.org/",
-    "isAbpSubscribable": true,
-    "name": "uBlock"
-  },
-  {
     "id": 16,
     "downloadUrl": "https://support.microsoft.com/en-gb/help/18520/download-internet-explorer-11-offline-installer",
     "homeUrl": "https://docs.microsoft.com/en-us/previous-versions/windows/internet-explorer/ie-developer/platform-apis/hh273399(v=vs.85)",

--- a/data/SoftwareSyntax.json
+++ b/data/SoftwareSyntax.json
@@ -28,10 +28,6 @@
     "syntaxId": 1
   },
   {
-    "softwareId": 15,
-    "syntaxId": 1
-  },
-  {
     "softwareId": 22,
     "syntaxId": 1
   },
@@ -53,10 +49,6 @@
   },
   {
     "softwareId": 14,
-    "syntaxId": 2
-  },
-  {
-    "softwareId": 15,
     "syntaxId": 2
   },
   {
@@ -89,10 +81,6 @@
   },
   {
     "softwareId": 6,
-    "syntaxId": 3
-  },
-  {
-    "softwareId": 15,
     "syntaxId": 3
   },
   {


### PR DESCRIPTION
I know that FilterLists has a policy of not picking one software tool over another, but I've got some arguments that I want to voice.

I've given uBlock LLC the benefit of the doubt in the past 6 months, after they were bought out by AdBlock and promised big changes. Now that we're in November, it turns out that the changes have been... almost zero. Judging by https://github.com/uBlock-LLC/uBlock/commits/master: In the past 5 months they've made only 18 commits (20 commits if we count their Mac app repo).

* Their new website is confusing, and seems to me to have been hastily constructed to show off random information and their Mac app.
* Their included filterlists, as per https://github.com/uBlock-LLC/uBlock/blob/master/assets/ublock/filter-lists.json, is a disaster, with no one involved having bothered to check if their lists are even alive or not. In particular, it still includes the abomination against nature that was the old Fredfiber Norwegian list.

So even if we were to look past [the accusations](https://github.com/gorhill/uBlock/wiki/Badware-risks#ublockorg) of tracking inclusions (They've added an opt-out option, but still) and whether or not it's spyware/trackware, I think it's a dead prospect that has no future ahead of it, and that they've been lying big time when they said they were refurbishing it.

I have now made my case, so I'll leave it up to you (Collin) whether you accept my proposition or not.
