### PR TITLE
Early February pull

### DIFF
--- a/data/FilterList.json
+++ b/data/FilterList.json
@@ -6272,7 +6272,8 @@
     "publishedDate": "2017-05-06T16:37:22",
     "syntaxId": 2,
     "updatedDate": "2019-01-03T04:47:29",
-    "viewUrl": "https://raw.githubusercontent.com/chadmayfield/my-pihole-blocklists/master/lists/pi_blocklist_porn_top1m.list"
+    "viewUrl": "https://raw.githubusercontent.com/chadmayfield/my-pihole-blocklists/master/lists/pi_blocklist_porn_top1m.list",
+    "viewUrlMirror1": "https://raw.githubusercontent.com/deathbybandaid/piholeparser/master/Subscribable-Lists/ParsedBlacklists/Chad-Mayfield-Porn-Blocklist-Light.txt"
   },
   {
     "id": 526,
@@ -6285,7 +6286,8 @@
     "publishedDate": "2017-05-06T16:37:22",
     "syntaxId": 2,
     "updatedDate": "2019-01-03T04:47:29",
-    "viewUrl": "https://raw.githubusercontent.com/chadmayfield/my-pihole-blocklists/master/lists/pi_blocklist_porn_all.list"
+    "viewUrl": "https://raw.githubusercontent.com/chadmayfield/my-pihole-blocklists/master/lists/pi_blocklist_porn_all.list",
+    "viewUrlMirror1": "https://raw.githubusercontent.com/deathbybandaid/piholeparser/master/Subscribable-Lists/ParsedBlacklists/Chad-Mayfield-Porn-Blocklist-Heavy.txt"
   },
   {
     "id": 527,
@@ -9206,7 +9208,7 @@
     "forumUrl": "https://forums.lanik.us/viewforum.php?f=91",
     "homeUrl": "https://easylist.to/",
     "licenseId": 6,
-    "name": "Liste FR",
+    "name": "Liste FR (TPL)",
     "syntaxId": 10,
     "updatedDate": "2018-12-17T04:37:11",
     "viewUrl": "https://easylist-msie.adblockplus.org/liste_fr.tpl"
@@ -10338,7 +10340,7 @@
     "licenseId": 5,
     "name": "Complete Mochi Filter",
     "publishedDate": "2018-02-16T23:42:21",
-    "syntaxId": 4,
+    "syntaxId": 21,
     "updatedDate": "2019-01-14T15:03:10",
     "viewUrl": "https://raw.githubusercontent.com/eEIi0A5L/adblock_filter/master/all.txt"
   },
@@ -13074,28 +13076,6 @@
     "viewUrl": "https://raw.githubusercontent.com/deathbybandaid/piholeparser/master/Subscribable-Lists/ParsedBlacklists/CAMELEON-Hosts.txt"
   },
   {
-    "id": 1131,
-    "homeUrl": "https://github.com/deathbybandaid/piholeparser",
-    "issuesUrl": "https://github.com/deathbybandaid/piholeparser/issues",
-    "licenseId": 14,
-    "name": "Chad Mayfield Porn Blocklist Heavy (Domains)",
-    "publishedDate": "2017-09-02T01:07:36",
-    "syntaxId": 2,
-    "updatedDate": "2019-01-04T00:43:49",
-    "viewUrl": "https://raw.githubusercontent.com/deathbybandaid/piholeparser/master/Subscribable-Lists/ParsedBlacklists/Chad-Mayfield-Porn-Blocklist-Heavy.txt"
-  },
-  {
-    "id": 1132,
-    "homeUrl": "https://github.com/deathbybandaid/piholeparser",
-    "issuesUrl": "https://github.com/deathbybandaid/piholeparser/issues",
-    "licenseId": 14,
-    "name": "Chad Mayfield Porn Blocklist Light (Domains)",
-    "publishedDate": "2017-09-02T01:07:36",
-    "syntaxId": 2,
-    "updatedDate": "2018-05-28T14:02:55",
-    "viewUrl": "https://raw.githubusercontent.com/deathbybandaid/piholeparser/master/Subscribable-Lists/ParsedBlacklists/Chad-Mayfield-Porn-Blocklist-Light.txt"
-  },
-  {
     "id": 1133,
     "homeUrl": "https://github.com/deathbybandaid/piholeparser",
     "issuesUrl": "https://github.com/deathbybandaid/piholeparser/issues",
@@ -13107,37 +13087,15 @@
     "viewUrl": "https://raw.githubusercontent.com/deathbybandaid/piholeparser/master/Subscribable-Lists/ParsedBlacklists/CryptoWall-Ransomware-C2-Domain-blocklist.txt"
   },
   {
-    "id": 1134,
-    "homeUrl": "https://github.com/deathbybandaid/piholeparser",
-    "issuesUrl": "https://github.com/deathbybandaid/piholeparser/issues",
-    "licenseId": 14,
-    "name": "DNS BH Free Web Hosts (Domains)",
-    "publishedDate": "2017-09-02T01:07:36",
-    "syntaxId": 2,
-    "updatedDate": "2018-05-28T14:02:55",
-    "viewUrl": "https://raw.githubusercontent.com/deathbybandaid/piholeparser/master/Subscribable-Lists/ParsedBlacklists/DNS-BH-Free-Web-Hosts.txt"
-  },
-  {
     "id": 1135,
     "homeUrl": "https://github.com/deathbybandaid/piholeparser",
     "issuesUrl": "https://github.com/deathbybandaid/piholeparser/issues",
     "licenseId": 14,
-    "name": "DNS BH Malware Domains (Domains)",
+    "name": "DNS-BH Malware Domains (Domains)",
     "publishedDate": "2017-09-02T01:07:36",
     "syntaxId": 2,
     "updatedDate": "2019-01-11T00:46:31",
     "viewUrl": "https://raw.githubusercontent.com/deathbybandaid/piholeparser/master/Subscribable-Lists/ParsedBlacklists/DNS-BH-Malware-Domains.txt"
-  },
-  {
-    "id": 1136,
-    "homeUrl": "https://github.com/deathbybandaid/piholeparser",
-    "issuesUrl": "https://github.com/deathbybandaid/piholeparser/issues",
-    "licenseId": 14,
-    "name": "Dan Pollock's Hosts (Domains)",
-    "publishedDate": "2017-09-02T01:07:36",
-    "syntaxId": 2,
-    "updatedDate": "2018-07-16T00:38:05",
-    "viewUrl": "https://raw.githubusercontent.com/deathbybandaid/piholeparser/master/Subscribable-Lists/ParsedBlacklists/Dan-Pollocks-Hosts.txt"
   },
   {
     "id": 1139,
@@ -13369,17 +13327,6 @@
     "syntaxId": 2,
     "updatedDate": "2018-05-28T14:02:55",
     "viewUrl": "https://raw.githubusercontent.com/deathbybandaid/piholeparser/master/Subscribable-Lists/ParsedBlacklists/JapaneseSiteAdblockFilterver2.txt"
-  },
-  {
-    "id": 1163,
-    "homeUrl": "https://github.com/deathbybandaid/piholeparser",
-    "issuesUrl": "https://github.com/deathbybandaid/piholeparser/issues",
-    "licenseId": 14,
-    "name": "JoeWein (Domains)",
-    "publishedDate": "2017-09-02T01:07:36",
-    "syntaxId": 2,
-    "updatedDate": "2019-01-17T00:41:59",
-    "viewUrl": "https://raw.githubusercontent.com/deathbybandaid/piholeparser/master/Subscribable-Lists/ParsedBlacklists/JoeWein.txt"
   },
   {
     "id": 1165,
@@ -13688,28 +13635,6 @@
     "syntaxId": 2,
     "updatedDate": "2018-05-28T14:02:55",
     "viewUrl": "https://raw.githubusercontent.com/deathbybandaid/piholeparser/master/Subscribable-Lists/ParsedBlacklists/Spam-Assassin-Bill-Stearns.txt"
-  },
-  {
-    "id": 1200,
-    "homeUrl": "https://github.com/deathbybandaid/piholeparser",
-    "issuesUrl": "https://github.com/deathbybandaid/piholeparser/issues",
-    "licenseId": 14,
-    "name": "Spam404 Domain Blacklist (Domains)",
-    "publishedDate": "2017-09-02T01:07:36",
-    "syntaxId": 2,
-    "updatedDate": "2018-05-28T14:02:55",
-    "viewUrl": "https://raw.githubusercontent.com/deathbybandaid/piholeparser/master/Subscribable-Lists/ParsedBlacklists/Spam404-Domain-Blacklist.txt"
-  },
-  {
-    "id": 1201,
-    "homeUrl": "https://github.com/deathbybandaid/piholeparser",
-    "issuesUrl": "https://github.com/deathbybandaid/piholeparser/issues",
-    "licenseId": 14,
-    "name": "Spam404 (Domains)",
-    "publishedDate": "2017-09-02T01:07:36",
-    "syntaxId": 2,
-    "updatedDate": "2018-05-28T14:02:55",
-    "viewUrl": "https://raw.githubusercontent.com/deathbybandaid/piholeparser/master/Subscribable-Lists/ParsedBlacklists/Spam404.txt"
   },
   {
     "id": 1202,

--- a/data/FilterList.json
+++ b/data/FilterList.json
@@ -5215,7 +5215,7 @@
     "updatedDate": "2018-12-04T14:41:10",
     "viewUrl": "https://raw.githubusercontent.com/DandelionSprout/adfilt/master/Dandelion%20Sprout's%20Website%20Stretcher.txt",
     "viewUrlMirror1": "https://repo.or.cz/FilterMirrorRepo.git/blob_plain/refs/heads/master:/Dandelion%20Sprout%27s%20Website%20Stretcher.txt",
-    "viewUrlMirror2": "https://gitlab.com/DandelionSprout/adfilt/raw/master/Dandelion%20Sprout%27s%20Website%20Stretcher.txt""
+    "viewUrlMirror2": "https://gitlab.com/DandelionSprout/adfilt/raw/master/Dandelion%20Sprout%27s%20Website%20Stretcher.txt"
   },
   {
     "id": 432,

--- a/data/FilterList.json
+++ b/data/FilterList.json
@@ -9599,7 +9599,7 @@
     "publishedDate": "2017-08-10T04:05:10",
     "syntaxId": 3,
     "updatedDate": "2019-01-06T10:44:42",
-    "viewUrl": "https://raw.githubusercontent.com/evenxzero/Raajje-AdList/master/filter"
+    "viewUrl": "https://raw.githubusercontent.com/evenxzero/Raajje-AdList/master/filter.txt"
   },
   {
     "id": 829,

--- a/data/FilterList.json
+++ b/data/FilterList.json
@@ -4787,7 +4787,7 @@
   },
   {
     "id": 389,
-    "description": "Here's how this list works. This is a categorised list of URLs that clot up Google search results. The list is designed for use with Google Hit Hider by Domain (and its Import function) for Google Search and Google Chrome users, in such a way that it removes search results for the URLs from your Google searches. If any other URL-based search-result-blockers for other search engines (incl. for Google Image Search) and browsers exist out there, feel free to tell me about them. The list is VERY subjective, so quite a few of you may NOT want to block the results for ALL of these URLs. In that case, simply pick whichever ones from this buffet that you want to block, and paste them into Google Hit Hider by Domain. While this list is technically possible to add to adblocker tools, it'd be a very bad idea to do so, since you wouldn't have any control over which URLs you'll be able to block outright or not.",
+    "description": "Here's how this list works. This is a categorised list of URLs that clot up Google search results. The list is designed for use with Google Hit Hider by Domain (and its Import function), in such a way that it removes search results for the URLs from your searches. The list is VERY subjective, so quite a few of you may NOT want to block the results for ALL of these URLs. In that case, simply pick whichever ones from this buffet that you want to block, and paste them into Google Hit Hider by Domain. While this list is technically possible to add to adblocker tools, it'd be a very bad idea to do so, since you wouldn't have any control over which URLs you'll be able to block outright or not.",
     "donateUrl": "https://sproutsluckycorner.wordpress.com/2017/11/14/my-work-and-contact-resume/#donations",
     "emailAddress": "imreeil42@gmail.com",
     "homeUrl": "https://github.com/DandelionSprout/adfilt",
@@ -4954,15 +4954,6 @@
     "syntaxId": 1,
     "updatedDate": "2019-01-03T03:59:50",
     "viewUrl": "https://raw.githubusercontent.com/notracking/hosts-blocklists/master/hostnames.txt"
-  },
-  {
-    "id": 402,
-    "homeUrl": "https://startshop.no/",
-    "licenseId": 5,
-    "name": "Startshop ABP Filters",
-    "syntaxId": 3,
-    "updatedDate": "2015-11-18T00:00:00",
-    "viewUrl": "https://startshop.no/filter/abp"
   },
   {
     "id": 403,
@@ -9908,7 +9899,7 @@
     "licenseId": 10,
     "name": "YouTube: Yet Even More Pure Video Experience",
     "publishedDate": "2018-10-12T18:43:20",
-    "syntaxId": 4,
+    "syntaxId": 21,
     "updatedDate": "2018-10-12T18:43:20",
     "viewUrl": "https://raw.githubusercontent.com/DandelionSprout/adfilt/master/YouTubeYetEvenMorePureVideoExperience.txt",
     "viewUrlMirror1": "https://repo.or.cz/FilterMirrorRepo.git/blob_plain/refs/heads/master:/YouTubeYetEvenMorePureVideoExperience.txt"
@@ -9924,26 +9915,10 @@
     "licenseId": 10,
     "name": "Dandelion Sprout's Very Thorough Website Cleaner",
     "publishedDate": "2018-10-12T18:49:52",
-    "syntaxId": 4,
+    "syntaxId": 21,
     "updatedDate": "2019-01-04T15:37:06",
     "viewUrl": "https://raw.githubusercontent.com/DandelionSprout/adfilt/master/VeryThoroughWebsiteCleaner.txt",
     "viewUrlMirror1": "https://repo.or.cz/FilterMirrorRepo.git/blob_plain/refs/heads/master:/VeryThoroughWebsiteCleaner.txt"
-  },
-  {
-    "id": 854,
-    "description": "Evidon is a platform that helps websites display GDPR notifications for European users. However, their displaying does temporarily break some elements on some sites... and can even break them outright if using certain adblock lists that prevent cookie notifications. The problem is believed to be even more frequent in non-EU EEC countries like Norway. So if you find yourself frustrated by the breakage, this list is for you.",
-    "descriptionSourceUrl": "https://raw.githubusercontent.com/DandelionSprout/adfilt/master/EvidonUnbreaker.txt",
-    "donateUrl": "https://sproutsluckycorner.wordpress.com/2017/11/14/my-work-and-contact-resume/#donations",
-    "emailAddress": "imreeil42@gmail.com",
-    "homeUrl": "https://github.com/DandelionSprout/adfilt",
-    "issuesUrl": "https://github.com/DandelionSprout/adfilt/issues",
-    "licenseId": 10,
-    "name": "Evidon Unbreaker",
-    "publishedDate": "2018-10-21T09:57:28",
-    "syntaxId": 3,
-    "updatedDate": "2018-10-21T09:57:28",
-    "viewUrl": "https://raw.githubusercontent.com/DandelionSprout/adfilt/master/EvidonUnbreaker.txt",
-    "viewUrlMirror1": "https://repo.or.cz/FilterMirrorRepo.git/blob_plain/refs/heads/master:/EvidonUnbreaker.txt"
   },
   {
     "id": 855,

--- a/data/FilterList.json
+++ b/data/FilterList.json
@@ -14780,7 +14780,7 @@
   },
   {
     "id": 1290,
-    "description": "Most anti-malware lists are pretty big and can cover a 5- or 6-digit amount of specific domains. But my list hereby claims to remove more than 25% of all known malware sites with just a 2-digit amount of entries. This is mostly done by blocking top-level domains that have become devastatingly abused by spammers, usually because they allowed for free and uncontrolled domain registrations.",
+    "description": "Most anti-malware lists are pretty big and can cover a 5- or 6-digit amount of specific domains. But my list hereby claims to remove more than 25% of all known malware sites with just a 2-digit amount of entries. This is mostly done by blocking top-level domains that have become devastatingly abused by spammers, usually because they allowed for free and uncontrolled domain registrations. There's also additional categories that cover unusual malware and phishing domains that no other lists seem to cover.",
     "descriptionSourceUrl": "https://raw.githubusercontent.com/DandelionSprout/adfilt/master/Dandelion%20Sprout's%20Anti-Malware%20List.txt",
     "donateUrl": "https://sproutsluckycorner.wordpress.com/2017/11/14/my-work-and-contact-resume/#donations",
     "emailAddress": "imreeil42@gmail.com",

--- a/data/FilterList.json
+++ b/data/FilterList.json
@@ -14838,7 +14838,7 @@
     "syntaxId": 1,
     "viewUrl": "https://raw.githubusercontent.com/DandelionSprout/adfilt/master/Adblock%20list%20templates/Adblock%20list%20template%20-Hosts%20and%20uBlock%20Origin-.txt",
     "viewUrlMirror1": "https://repo.or.cz/FilterMirrorRepo.git/blob_plain/refs/heads/master:/Adblock%20list%20templates/Adblock%20list%20template%20-Hosts%20and%20uBlock%20Origin-.txt",
-    "viewUrlMirror2": "https://gitlab.com/DandelionSprout/adfilt/raw/master/Adblock%20list%20templates/Adblock%20list%20template%20-Hosts%20and%20uBlock%20Origin-.txt""
+    "viewUrlMirror2": "https://gitlab.com/DandelionSprout/adfilt/raw/master/Adblock%20list%20templates/Adblock%20list%20template%20-Hosts%20and%20uBlock%20Origin-.txt"
   },
   {
     "id": 1294,

--- a/data/FilterList.json
+++ b/data/FilterList.json
@@ -250,7 +250,8 @@
     "syntaxId": 3,
     "updatedDate": "2019-01-11T20:22:07",
     "viewUrl": "https://raw.githubusercontent.com/DandelionSprout/adfilt/master/NorwegianList.txt",
-    "viewUrlMirror1": "https://repo.or.cz/FilterMirrorRepo.git/blob_plain/refs/heads/master:/NorwegianList.txt"
+    "viewUrlMirror1": "https://repo.or.cz/FilterMirrorRepo.git/blob_plain/refs/heads/master:/NorwegianList.txt",
+    "viewUrlMirror2": "https://gitlab.com/DandelionSprout/adfilt/raw/master/NorwegianList.txt"
   },
   {
     "id": 21,
@@ -4029,7 +4030,8 @@
     "syntaxId": 3,
     "updatedDate": "2018-09-30T03:39:52",
     "viewUrl": "https://raw.githubusercontent.com/DandelionSprout/adfilt/master/stayingonbrowser/Staying%20On%20The%20Phone%20Browser",
-    "viewUrlMirror1": "https://repo.or.cz/FilterMirrorRepo.git/blob_plain/refs/heads/master:/stayingonbrowser/Staying%20On%20The%20Phone%20Browser"
+    "viewUrlMirror1": "https://repo.or.cz/FilterMirrorRepo.git/blob_plain/refs/heads/master:/stayingonbrowser/Staying%20On%20The%20Phone%20Browser",
+    "viewUrlMirror2": "https://gitlab.com/DandelionSprout/adfilt/raw/master/stayingonbrowser/Staying%20On%20The%20Phone%20Browser"
   },
   {
     "id": 329,
@@ -4770,7 +4772,8 @@
     "syntaxId": 3,
     "updatedDate": "2018-09-30T08:52:54",
     "viewUrl": "https://raw.githubusercontent.com/DandelionSprout/adfilt/master/Username%20Hider%20for%20Compilation%20Creators.txt",
-    "viewUrlMirror1": "https://repo.or.cz/FilterMirrorRepo.git/blob_plain/refs/heads/master:/Username%20Hider%20for%20Compilation%20Creators.txt"
+    "viewUrlMirror1": "https://repo.or.cz/FilterMirrorRepo.git/blob_plain/refs/heads/master:/Username%20Hider%20for%20Compilation%20Creators.txt",
+    "viewUrlMirror2": "https://gitlab.com/DandelionSprout/adfilt/raw/master/Username%20Hider%20for%20Compilation%20Creators.txt"
   },
   {
     "id": 388,
@@ -4783,7 +4786,8 @@
     "name": "Dandelion Sprout's Norwegian Filters for Tidier Websites (Internet Explorer)",
     "syntaxId": 10,
     "viewUrl": "https://raw.githubusercontent.com/DandelionSprout/adfilt/master/NorwegianExperimentalList%20alternate%20versions/DandelionSproutsNorskeFiltre.tpl",
-    "viewUrlMirror1": "https://repo.or.cz/FilterMirrorRepo.git/blob_plain/refs/heads/master:/NorwegianExperimentalList%20alternate%20versions/DandelionSproutsNorskeFiltre.tpl"
+    "viewUrlMirror1": "https://repo.or.cz/FilterMirrorRepo.git/blob_plain/refs/heads/master:/NorwegianExperimentalList%20alternate%20versions/DandelionSproutsNorskeFiltre.tpl",
+    "viewUrlMirror2": "https://gitlab.com/DandelionSprout/adfilt/raw/master/NorwegianExperimentalList%20alternate%20versions/DandelionSproutsNorskeFiltre.tpl"
   },
   {
     "id": 389,
@@ -4826,7 +4830,8 @@
     "syntaxId": 3,
     "updatedDate": "2018-12-04T21:41:01",
     "viewUrl": "https://raw.githubusercontent.com/DandelionSprout/adfilt/master/IHateOverpromotedGames.txt",
-    "viewUrlMirror1": "https://repo.or.cz/FilterMirrorRepo.git/blob_plain/refs/heads/master:/IHateOverpromotedGames.txt"
+    "viewUrlMirror1": "https://repo.or.cz/FilterMirrorRepo.git/blob_plain/refs/heads/master:/IHateOverpromotedGames.txt",
+    "viewUrlMirror2": "https://gitlab.com/DandelionSprout/adfilt/raw/master/IHateOverpromotedGames.txt"
   },
   {
     "id": 392,
@@ -4841,7 +4846,8 @@
     "syntaxId": 3,
     "updatedDate": "2018-12-31T06:16:23",
     "viewUrl": "https://raw.githubusercontent.com/DandelionSprout/adfilt/master/BrowseWebsitesWithoutLoggingIn.txt",
-    "viewUrlMirror1": "https://repo.or.cz/FilterMirrorRepo.git/blob_plain/refs/heads/master:/BrowseWebsitesWithoutLoggingIn.txt"
+    "viewUrlMirror1": "https://repo.or.cz/FilterMirrorRepo.git/blob_plain/refs/heads/master:/BrowseWebsitesWithoutLoggingIn.txt",
+    "viewUrlMirror2": "https://gitlab.com/DandelionSprout/adfilt/raw/master/BrowseWebsitesWithoutLoggingIn.txt"
   },
   {
     "id": 393,
@@ -4856,7 +4862,8 @@
     "syntaxId": 11,
     "updatedDate": "2018-10-26T14:58:08",
     "viewUrl": "https://raw.githubusercontent.com/DandelionSprout/adfilt/master/Dandelion%20Sprout-s%20Redirector%20Assistant%20List/DandelionSproutRedirectorList.json",
-    "viewUrlMirror1": "https://repo.or.cz/FilterMirrorRepo.git/blob_plain/refs/heads/master:/Dandelion%20Sprout-s%20Redirector%20Assistant%20List/DandelionSproutRedirectorList.json"
+    "viewUrlMirror1": "https://repo.or.cz/FilterMirrorRepo.git/blob_plain/refs/heads/master:/Dandelion%20Sprout-s%20Redirector%20Assistant%20List/DandelionSproutRedirectorList.json",
+    "viewUrlMirror2": "https://gitlab.com/DandelionSprout/adfilt/raw/master/Dandelion%20Sprout-s%20Redirector%20Assistant%20List/DandelionSproutRedirectorList.json"
   },
   {
     "id": 394,
@@ -5192,7 +5199,8 @@
     "syntaxId": 1,
     "updatedDate": "2018-09-30T15:15:50",
     "viewUrl": "https://raw.githubusercontent.com/DandelionSprout/adfilt/master/NorwegianExperimentalList%20alternate%20versions/AdawayHosts",
-    "viewUrlMirror1": "https://repo.or.cz/FilterMirrorRepo.git/blob_plain/refs/heads/master:/NorwegianExperimentalList%20alternate%20versions/AdawayHosts"
+    "viewUrlMirror1": "https://repo.or.cz/FilterMirrorRepo.git/blob_plain/refs/heads/master:/NorwegianExperimentalList%20alternate%20versions/AdawayHosts",
+    "viewUrlMirror2": "https://gitlab.com/DandelionSprout/adfilt/raw/master/NorwegianExperimentalList%20alternate%20versions/AdawayHosts"
   },
   {
     "id": 431,
@@ -5206,7 +5214,8 @@
     "syntaxId": 4,
     "updatedDate": "2018-12-04T14:41:10",
     "viewUrl": "https://raw.githubusercontent.com/DandelionSprout/adfilt/master/Dandelion%20Sprout's%20Website%20Stretcher.txt",
-    "viewUrlMirror1": "https://repo.or.cz/FilterMirrorRepo.git/blob_plain/refs/heads/master:/Dandelion%20Sprout%27s%20Website%20Stretcher.txt"
+    "viewUrlMirror1": "https://repo.or.cz/FilterMirrorRepo.git/blob_plain/refs/heads/master:/Dandelion%20Sprout%27s%20Website%20Stretcher.txt",
+    "viewUrlMirror2": "https://gitlab.com/DandelionSprout/adfilt/raw/master/Dandelion%20Sprout%27s%20Website%20Stretcher.txt""
   },
   {
     "id": 432,
@@ -5220,7 +5229,8 @@
     "syntaxId": 3,
     "updatedDate": "2018-12-16T01:28:09",
     "viewUrl": "https://raw.githubusercontent.com/DandelionSprout/adfilt/master/Anti-F%D1%96%D0%9C%20List.txt",
-    "viewUrlMirror1": "https://repo.or.cz/FilterMirrorRepo.git/blob_plain/refs/heads/master:/Anti-F%D1%96%D0%9C%20List.txt"
+    "viewUrlMirror1": "https://repo.or.cz/FilterMirrorRepo.git/blob_plain/refs/heads/master:/Anti-F%D1%96%D0%9C%20List.txt",
+    "viewUrlMirror2": "https://gitlab.com/DandelionSprout/adfilt/raw/master/Anti-F%D1%96%D0%9C%20List.txt"
   },
   {
     "id": 433,
@@ -5234,7 +5244,8 @@
     "syntaxId": 4,
     "updatedDate": "2018-12-16T01:34:13",
     "viewUrl": "https://raw.githubusercontent.com/DandelionSprout/adfilt/master/Anti-IMDB%20List.txt",
-    "viewUrlMirror1": "https://repo.or.cz/FilterMirrorRepo.git/blob_plain/refs/heads/master:/Anti-IMDB%20List.txt"
+    "viewUrlMirror1": "https://repo.or.cz/FilterMirrorRepo.git/blob_plain/refs/heads/master:/Anti-IMDB%20List.txt",
+    "viewUrlMirror2": "https://gitlab.com/DandelionSprout/adfilt/raw/master/Anti-IMDB%20List.txt"
   },
   {
     "id": 434,
@@ -5249,7 +5260,8 @@
     "syntaxId": 3,
     "updatedDate": "2018-12-19T09:39:03",
     "viewUrl": "https://raw.githubusercontent.com/DandelionSprout/adfilt/master/StopAutoplayOnYouTube.txt",
-    "viewUrlMirror1": "https://repo.or.cz/FilterMirrorRepo.git/blob_plain/refs/heads/master:/StopAutoplayOnYouTube.txt"
+    "viewUrlMirror1": "https://repo.or.cz/FilterMirrorRepo.git/blob_plain/refs/heads/master:/StopAutoplayOnYouTube.txt",
+    "viewUrlMirror2": "https://gitlab.com/DandelionSprout/adfilt/raw/master/StopAutoplayOnYouTube.txt"
   },
   {
     "id": 435,
@@ -6015,7 +6027,8 @@
     "name": "Adblock List Template (Beginner)",
     "syntaxId": 3,
     "viewUrl": "https://raw.githubusercontent.com/DandelionSprout/adfilt/master/Adblock%20list%20templates/Adblock%20list%20template%20-Beginner-.txt",
-    "viewUrlMirror1": "https://repo.or.cz/FilterMirrorRepo.git/blob_plain/refs/heads/master:/Adblock%20list%20templates/Adblock%20list%20template%20-Beginner-.txt"
+    "viewUrlMirror1": "https://repo.or.cz/FilterMirrorRepo.git/blob_plain/refs/heads/master:/Adblock%20list%20templates/Adblock%20list%20template%20-Beginner-.txt",
+    "viewUrlMirror2": "https://gitlab.com/DandelionSprout/adfilt/raw/master/Adblock%20list%20templates/Adblock%20list%20template%20-Beginner-.txt"
   },
   {
     "id": 505,
@@ -6028,7 +6041,8 @@
     "name": "Adblock List Template (Novice)",
     "syntaxId": 3,
     "viewUrl": "https://raw.githubusercontent.com/DandelionSprout/adfilt/master/Adblock%20list%20templates/Adblock%20list%20template%20-Novice-.txt",
-    "viewUrlMirror1": "https://repo.or.cz/FilterMirrorRepo.git/blob_plain/refs/heads/master:/Adblock%20list%20templates/Adblock%20list%20template%20-Novice-.txt"
+    "viewUrlMirror1": "https://repo.or.cz/FilterMirrorRepo.git/blob_plain/refs/heads/master:/Adblock%20list%20templates/Adblock%20list%20template%20-Novice-.txt",
+    "viewUrlMirror2": "https://gitlab.com/DandelionSprout/adfilt/raw/master/Adblock%20list%20templates/Adblock%20list%20template%20-Novice-.txt"
   },
   {
     "id": 506,
@@ -7149,7 +7163,8 @@
     "syntaxId": 3,
     "updatedDate": "2018-12-09T20:07:10",
     "viewUrl": "https://raw.githubusercontent.com/DandelionSprout/adfilt/master/Anti-Elsagate%20List.txt",
-    "viewUrlMirror1": "https://repo.or.cz/FilterMirrorRepo.git/blob_plain/refs/heads/master:/Anti-Elsagate%20List.txt"
+    "viewUrlMirror1": "https://repo.or.cz/FilterMirrorRepo.git/blob_plain/refs/heads/master:/Anti-Elsagate%20List.txt",
+    "viewUrlMirror2": "https://gitlab.com/DandelionSprout/adfilt/raw/master/Anti-Elsagate%20List.txt"
   },
   {
     "id": 604,
@@ -7831,7 +7846,8 @@
     "syntaxId": 18,
     "updatedDate": "2018-09-30T04:23:50",
     "viewUrl": "https://raw.githubusercontent.com/DandelionSprout/adfilt/master/NorwegianExperimentalList%20alternate%20versions/LittleSnitchNorwegianList.lsrules",
-    "viewUrlMirror1": "https://repo.or.cz/FilterMirrorRepo.git/blob_plain/refs/heads/master:/NorwegianExperimentalList%20alternate%20versions/LittleSnitchNorwegianList.lsrules"
+    "viewUrlMirror1": "https://repo.or.cz/FilterMirrorRepo.git/blob_plain/refs/heads/master:/NorwegianExperimentalList%20alternate%20versions/LittleSnitchNorwegianList.lsrules",
+    "viewUrlMirror2": "https://gitlab.com/DandelionSprout/adfilt/raw/master/NorwegianExperimentalList%20alternate%20versions/LittleSnitchNorwegianList.lsrules"
   },
   {
     "id": 671,
@@ -7945,7 +7961,8 @@
     "syntaxId": 2,
     "updatedDate": "2018-09-30T04:33:48",
     "viewUrl": "https://raw.githubusercontent.com/DandelionSprout/adfilt/master/NorwegianExperimentalList%20alternate%20versions/DandelionSproutsNorskeFiltreDomains.txt",
-    "viewUrlMirror1": "https://repo.or.cz/FilterMirrorRepo.git/blob_plain/refs/heads/master:/NorwegianExperimentalList%20alternate%20versions/DandelionSproutsNorskeFiltreDomains.txt"
+    "viewUrlMirror1": "https://repo.or.cz/FilterMirrorRepo.git/blob_plain/refs/heads/master:/NorwegianExperimentalList%20alternate%20versions/DandelionSproutsNorskeFiltreDomains.txt",
+    "viewUrlMirror2": "https://gitlab.com/DandelionSprout/adfilt/raw/master/NorwegianExperimentalList%20alternate%20versions/DandelionSproutsNorskeFiltreDomains.txt"
   },
   {
     "id": 681,
@@ -9431,7 +9448,8 @@
     "syntaxId": 4,
     "updatedDate": "2019-01-14T00:42:10",
     "viewUrl": "https://raw.githubusercontent.com/DandelionSprout/adfilt/master/I%20Don't%20Want%20to%20Download%20Your%20Browser.txt",
-    "viewUrlMirror1": "https://repo.or.cz/FilterMirrorRepo.git/blob_plain/refs/heads/master:/I%20Don't%20Want%20to%20Download%20Your%20Browser.txt"
+    "viewUrlMirror1": "https://repo.or.cz/FilterMirrorRepo.git/blob_plain/refs/heads/master:/I%20Don't%20Want%20to%20Download%20Your%20Browser.txt",
+    "viewUrlMirror2": "https://gitlab.com/DandelionSprout/adfilt/raw/master/I%20Don't%20Want%20to%20Download%20Your%20Browser.txt"
   },
   {
     "id": 817,
@@ -9471,7 +9489,8 @@
     "syntaxId": 3,
     "updatedDate": "2019-01-10T01:23:26",
     "viewUrl": "https://raw.githubusercontent.com/DandelionSprout/adfilt/master/YouTubeEvenMorePureVideoExperience.txt",
-    "viewUrlMirror1": "https://repo.or.cz/FilterMirrorRepo.git/blob_plain/refs/heads/master:/YouTubeEvenMorePureVideoExperience.txt"
+    "viewUrlMirror1": "https://repo.or.cz/FilterMirrorRepo.git/blob_plain/refs/heads/master:/YouTubeEvenMorePureVideoExperience.txt",
+    "viewUrlMirror2": "https://gitlab.com/DandelionSprout/adfilt/raw/master/YouTubeEvenMorePureVideoExperience.txt"
   },
   {
     "id": 820,
@@ -9839,7 +9858,8 @@
     "syntaxId": 3,
     "updatedDate": "2018-12-19T08:44:16",
     "viewUrl": "https://raw.githubusercontent.com/DandelionSprout/adfilt/master/TwitchPureViewingExperience.txt",
-    "viewUrlMirror1": "https://repo.or.cz/FilterMirrorRepo.git/blob_plain/refs/heads/master:/TwitchPureViewingExperience.txt"
+    "viewUrlMirror1": "https://repo.or.cz/FilterMirrorRepo.git/blob_plain/refs/heads/master:/TwitchPureViewingExperience.txt",
+    "viewUrlMirror2": "https://gitlab.com/DandelionSprout/adfilt/raw/master/TwitchPureViewingExperience.txt"
   },
   {
     "id": 849,
@@ -9854,7 +9874,8 @@
     "syntaxId": 3,
     "updatedDate": "2018-11-04T02:57:03",
     "viewUrl": "https://raw.githubusercontent.com/DandelionSprout/adfilt/master/ListAgainstFakeOrInoptimalAdblockers.txt",
-    "viewUrlMirror1": "https://repo.or.cz/FilterMirrorRepo.git/blob_plain/refs/heads/master:/ListAgainstFakeOrInoptimalAdblockers.txt"
+    "viewUrlMirror1": "https://repo.or.cz/FilterMirrorRepo.git/blob_plain/refs/heads/master:/ListAgainstFakeOrInoptimalAdblockers.txt",
+    "viewUrlMirror2": "https://gitlab.com/DandelionSprout/adfilt/raw/master/ListAgainstFakeOrInoptimalAdblockers.txt"
   },
   {
     "id": 850,
@@ -9870,7 +9891,8 @@
     "syntaxId": 3,
     "updatedDate": "2018-12-04T21:27:46",
     "viewUrl": "https://raw.githubusercontent.com/DandelionSprout/adfilt/master/AntiAbusePorn.txt",
-    "viewUrlMirror1": "https://repo.or.cz/FilterMirrorRepo.git/blob_plain/refs/heads/master:/AntiAbusePorn.txt"
+    "viewUrlMirror1": "https://repo.or.cz/FilterMirrorRepo.git/blob_plain/refs/heads/master:/AntiAbusePorn.txt",
+    "viewUrlMirror2": "https://gitlab.com/DandelionSprout/adfilt/raw/master/AntiAbusePorn.txt"
   },
   {
     "id": 851,
@@ -9886,7 +9908,8 @@
     "syntaxId": 3,
     "updatedDate": "2018-12-19T08:49:15",
     "viewUrl": "https://raw.githubusercontent.com/DandelionSprout/adfilt/master/WikiaPureBrowsingExperience.txt",
-    "viewUrlMirror1": "https://repo.or.cz/FilterMirrorRepo.git/blob_plain/refs/heads/master:/WikiaPureBrowsingExperience.txt"
+    "viewUrlMirror1": "https://repo.or.cz/FilterMirrorRepo.git/blob_plain/refs/heads/master:/WikiaPureBrowsingExperience.txt",
+    "viewUrlMirror2": "https://gitlab.com/DandelionSprout/adfilt/raw/master/WikiaPureBrowsingExperience.txt"
   },
   {
     "id": 852,
@@ -9902,7 +9925,8 @@
     "syntaxId": 21,
     "updatedDate": "2018-10-12T18:43:20",
     "viewUrl": "https://raw.githubusercontent.com/DandelionSprout/adfilt/master/YouTubeYetEvenMorePureVideoExperience.txt",
-    "viewUrlMirror1": "https://repo.or.cz/FilterMirrorRepo.git/blob_plain/refs/heads/master:/YouTubeYetEvenMorePureVideoExperience.txt"
+    "viewUrlMirror1": "https://repo.or.cz/FilterMirrorRepo.git/blob_plain/refs/heads/master:/YouTubeYetEvenMorePureVideoExperience.txt",
+    "viewUrlMirror2": "https://gitlab.com/DandelionSprout/adfilt/raw/master/YouTubeYetEvenMorePureVideoExperience.txt"
   },
   {
     "id": 853,
@@ -9918,7 +9942,8 @@
     "syntaxId": 21,
     "updatedDate": "2019-01-04T15:37:06",
     "viewUrl": "https://raw.githubusercontent.com/DandelionSprout/adfilt/master/VeryThoroughWebsiteCleaner.txt",
-    "viewUrlMirror1": "https://repo.or.cz/FilterMirrorRepo.git/blob_plain/refs/heads/master:/VeryThoroughWebsiteCleaner.txt"
+    "viewUrlMirror1": "https://repo.or.cz/FilterMirrorRepo.git/blob_plain/refs/heads/master:/VeryThoroughWebsiteCleaner.txt",
+    "viewUrlMirror2": "https://gitlab.com/DandelionSprout/adfilt/raw/master/VeryThoroughWebsiteCleaner.txt"
   },
   {
     "id": 855,
@@ -9932,7 +9957,8 @@
     "name": "MeWe Pink Theme",
     "syntaxId": 4,
     "viewUrl": "https://raw.githubusercontent.com/DandelionSprout/adfilt/master/MeWe%20Pink%20Theme.txt",
-    "viewUrlMirror1": "https://repo.or.cz/FilterMirrorRepo.git/blob_plain/refs/heads/master:/MeWe%20Pink%20Theme.txt"
+    "viewUrlMirror1": "https://repo.or.cz/FilterMirrorRepo.git/blob_plain/refs/heads/master:/MeWe%20Pink%20Theme.txt",
+    "viewUrlMirror2": "https://gitlab.com/DandelionSprout/adfilt/raw/master/MeWe%20Pink%20Theme.txt"
   },
   {
     "id": 856,
@@ -9947,7 +9973,8 @@
     "syntaxId": 3,
     "updatedDate": "2018-12-09T15:53:09",
     "viewUrl": "https://raw.githubusercontent.com/DandelionSprout/adfilt/master/Pro-LED%20List.txt",
-    "viewUrlMirror1": "https://repo.or.cz/FilterMirrorRepo.git/blob_plain/refs/heads/master:/Pro-LED%20List.txt"
+    "viewUrlMirror1": "https://repo.or.cz/FilterMirrorRepo.git/blob_plain/refs/heads/master:/Pro-LED%20List.txt",
+    "viewUrlMirror2": "https://gitlab.com/DandelionSprout/adfilt/raw/master/Pro-LED%20List.txt"
   },
   {
     "id": 857,
@@ -9962,7 +9989,8 @@
     "syntaxId": 11,
     "updatedDate": "2019-01-14T00:32:11",
     "viewUrl": "https://raw.githubusercontent.com/DandelionSprout/adfilt/master/Dandelion%20Sprout-s%20Redirector%20Assistant%20List/TorRedirectorList.json",
-    "viewUrlMirror1": "https://repo.or.cz/FilterMirrorRepo.git/blob_plain/refs/heads/master:/Dandelion%20Sprout-s%20Redirector%20Assistant%20List/TorRedirectorList.json"
+    "viewUrlMirror1": "https://repo.or.cz/FilterMirrorRepo.git/blob_plain/refs/heads/master:/Dandelion%20Sprout-s%20Redirector%20Assistant%20List/TorRedirectorList.json",
+    "viewUrlMirror2": "https://gitlab.com/DandelionSprout/adfilt/raw/master/Dandelion%20Sprout-s%20Redirector%20Assistant%20List/TorRedirectorList.json"
   },
   {
     "id": 858,
@@ -9991,7 +10019,8 @@
     "syntaxId": 3,
     "updatedDate": "2019-01-14T04:57:10",
     "viewUrl": "https://raw.githubusercontent.com/DandelionSprout/adfilt/master/Anti-Futa%20List.txt",
-    "viewUrlMirror1": "https://repo.or.cz/FilterMirrorRepo.git/blob_plain/refs/heads/master:/Anti-Futa%20List.txt"
+    "viewUrlMirror1": "https://repo.or.cz/FilterMirrorRepo.git/blob_plain/refs/heads/master:/Anti-Futa%20List.txt",
+    "viewUrlMirror2": "https://gitlab.com/DandelionSprout/adfilt/raw/master/Anti-Futa%20List.txt"
   },
   {
     "id": 860,
@@ -10046,7 +10075,8 @@
     "syntaxId": 3,
     "updatedDate": "2018-12-09T21:19:09",
     "viewUrl": "https://raw.githubusercontent.com/DandelionSprout/adfilt/master/Anti-'Christmas%20carols'%20List.txt",
-    "viewUrlMirror1": "https://repo.or.cz/FilterMirrorRepo.git/blob_plain/refs/heads/master:/Anti-'Christmas%20carols'%20List.txt"
+    "viewUrlMirror1": "https://repo.or.cz/FilterMirrorRepo.git/blob_plain/refs/heads/master:/Anti-'Christmas%20carols'%20List.txt",
+    "viewUrlMirror2": "https://gitlab.com/DandelionSprout/adfilt/raw/master/Anti-'Christmas%20carols'%20List.txt"
   },
   {
     "id": 864,
@@ -14176,7 +14206,8 @@
     "publishedDate": "2018-02-12T00:00:00",
     "syntaxId": 3,
     "viewUrl": "https://raw.githubusercontent.com/DandelionSprout/adfilt/master/Anti-'Notification%20pre-prompt%20banners'%20List.txt",
-    "viewUrlMirror1": "https://repo.or.cz/FilterMirrorRepo.git/blob_plain/refs/heads/master:/Anti-'Notification%20pre-prompt%20banners'%20List.txt"
+    "viewUrlMirror1": "https://repo.or.cz/FilterMirrorRepo.git/blob_plain/refs/heads/master:/Anti-'Notification%20pre-prompt%20banners'%20List.txt",
+    "viewUrlMirror2": "https://gitlab.com/DandelionSprout/adfilt/raw/master/Anti-'Notification%20pre-prompt%20banners'%20List.txt"
   },
   {
     "id": 1247,
@@ -14191,7 +14222,8 @@
     "syntaxId": 3,
     "updatedDate": "2018-12-14T04:43:10",
     "viewUrl": "https://raw.githubusercontent.com/DandelionSprout/adfilt/master/Anti-'Battle%20Royale'%20List.txt",
-    "viewUrlMirror1": "https://repo.or.cz/FilterMirrorRepo.git/blob_plain/refs/heads/master:/Anti-'Battle%20Royale'%20List.txt"
+    "viewUrlMirror1": "https://repo.or.cz/FilterMirrorRepo.git/blob_plain/refs/heads/master:/Anti-'Battle%20Royale'%20List.txt",
+    "viewUrlMirror2": "https://gitlab.com/DandelionSprout/adfilt/raw/master/Anti-'Battle%20Royale'%20List.txt"
   },
   {
     "id": 1248,
@@ -14712,7 +14744,8 @@
     "syntaxId": 3,
     "updatedDate": "2019-01-06T02:04:25",
     "viewUrl": "https://raw.githubusercontent.com/DandelionSprout/adfilt/master/TechnologicalDiversity.txt",
-    "viewUrlMirror1": "https://repo.or.cz/FilterMirrorRepo.git/blob_plain/refs/heads/master:/TechnologicalDiversity.txt"
+    "viewUrlMirror1": "https://repo.or.cz/FilterMirrorRepo.git/blob_plain/refs/heads/master:/TechnologicalDiversity.txt",
+    "viewUrlMirror2": "https://gitlab.com/DandelionSprout/adfilt/raw/master/TechnologicalDiversity.txt"
   },
   {
     "id": 1288,
@@ -14741,7 +14774,8 @@
     "syntaxId": 3,
     "updatedDate": "2019-01-04T15:35:57",
     "viewUrl": "https://raw.githubusercontent.com/DandelionSprout/adfilt/master/KnowYourMemePureBrowsingExperience.txt",
-    "viewUrlMirror1": "https://repo.or.cz/FilterMirrorRepo.git/blob_plain/refs/heads/master:/KnowYourMemePureBrowsingExperience.txt"
+    "viewUrlMirror1": "https://repo.or.cz/FilterMirrorRepo.git/blob_plain/refs/heads/master:/KnowYourMemePureBrowsingExperience.txt",
+    "viewUrlMirror2": "https://gitlab.com/DandelionSprout/adfilt/raw/master/KnowYourMemePureBrowsingExperience.txt"
   },
   {
     "id": 1290,
@@ -14756,7 +14790,8 @@
     "publishedDate": "2018-01-04T00:00:00",
     "syntaxId": 3,
     "viewUrl": "https://raw.githubusercontent.com/DandelionSprout/adfilt/master/Dandelion%20Sprout's%20Anti-Malware%20List.txt",
-    "viewUrlMirror1": "https://repo.or.cz/FilterMirrorRepo.git/blob_plain/refs/heads/master:/Dandelion%20Sprout's%20Anti-Malware%20List.txt"
+    "viewUrlMirror1": "https://repo.or.cz/FilterMirrorRepo.git/blob_plain/refs/heads/master:/Dandelion%20Sprout's%20Anti-Malware%20List.txt",
+    "viewUrlMirror2": "https://gitlab.com/DandelionSprout/adfilt/raw/master/Dandelion%20Sprout's%20Anti-Malware%20List.txt"
   },
   {
     "id": 1291,
@@ -14771,7 +14806,8 @@
     "publishedDate": "2018-01-10T00:00:00",
     "syntaxId": 3,
     "viewUrl": "https://raw.githubusercontent.com/DandelionSprout/adfilt/master/Twitter%20De-Politificator.txt",
-    "viewUrlMirror1": "https://repo.or.cz/FilterMirrorRepo.git/blob_plain/refs/heads/master:/Twitter%20De-Politificator.txt"
+    "viewUrlMirror1": "https://repo.or.cz/FilterMirrorRepo.git/blob_plain/refs/heads/master:/Twitter%20De-Politificator.txt",
+    "viewUrlMirror2": "https://gitlab.com/DandelionSprout/adfilt/raw/master/Twitter%20De-Politificator.txt"
   },
   {
     "id": 1292,
@@ -14786,7 +14822,8 @@
     "publishedDate": "2018-01-10T00:00:00",
     "syntaxId": 3,
     "viewUrl": "https://raw.githubusercontent.com/DandelionSprout/adfilt/master/Android%20Scum%20Class%20—%20Fake%20notification%20counters.txt",
-    "viewUrlMirror1": "https://repo.or.cz/FilterMirrorRepo.git/blob_plain/refs/heads/master:/Android%20Scum%20Class%20—%20Fake%20notification%20counters.txt"
+    "viewUrlMirror1": "https://repo.or.cz/FilterMirrorRepo.git/blob_plain/refs/heads/master:/Android%20Scum%20Class%20—%20Fake%20notification%20counters.txt",
+    "viewUrlMirror2": "https://gitlab.com/DandelionSprout/adfilt/raw/master/Android%20Scum%20Class%20—%20Fake%20notification%20counters.txt"
   },
   {
     "id": 1293,
@@ -14800,7 +14837,8 @@
     "publishedDate": "2018-01-10T00:00:00",
     "syntaxId": 1,
     "viewUrl": "https://raw.githubusercontent.com/DandelionSprout/adfilt/master/Adblock%20list%20templates/Adblock%20list%20template%20-Hosts%20and%20uBlock%20Origin-.txt",
-    "viewUrlMirror1": "https://repo.or.cz/FilterMirrorRepo.git/blob_plain/refs/heads/master:/Adblock%20list%20templates/Adblock%20list%20template%20-Hosts%20and%20uBlock%20Origin-.txt"
+    "viewUrlMirror1": "https://repo.or.cz/FilterMirrorRepo.git/blob_plain/refs/heads/master:/Adblock%20list%20templates/Adblock%20list%20template%20-Hosts%20and%20uBlock%20Origin-.txt",
+    "viewUrlMirror2": "https://gitlab.com/DandelionSprout/adfilt/raw/master/Adblock%20list%20templates/Adblock%20list%20template%20-Hosts%20and%20uBlock%20Origin-.txt""
   },
   {
     "id": 1294,
@@ -16564,5 +16602,65 @@
     "syntaxId": 8,
     "updatedDate": "2019-01-15T03:00:00",
     "viewUrl": "https://raw.githubusercontent.com/cbuijs/shallalist/master/webtv/urls"
-  }
+  },
+  {
+    "id": 1453,
+    "description": "This compilation list was made to help resolve two of the most frequent tech complaints on r/assholedesign: Websites that require logging in to browse them, and Android apps with fake notification counters. To that effect, this list embeds two of my other lists that covers either one of those purposes. This list requires using Nano Adblocker or uBlock Origin, the latter of which is also available for Firefox on Android phones, as they're the only adblockers that have full support for list embeddings. Now let's see how many months it'll take before anyone on that subreddit notices the existence of this list...",
+    "descriptionSourceUrl": "https://raw.githubusercontent.com/DandelionSprout/adfilt/master/ListForRAssholeDesign.txt",
+    "donateUrl": "https://sproutsluckycorner.wordpress.com/2017/11/14/my-work-and-contact-resume/#donations",
+    "emailAddress": "imreeil42@gmail.com",
+    "homeUrl": "https://github.com/DandelionSprout/adfilt",
+    "issuesUrl": "https://github.com/DandelionSprout/adfilt/issues",
+    "licenseId": 10,
+    "name": "Dandelion Sprout's List for the Benefit of r/assholedesign",
+    "syntaxId": 21,
+    "viewUrl": "https://raw.githubusercontent.com/DandelionSprout/adfilt/master/ListForRAssholeDesign.txt",
+    "viewUrlMirror1": "https://repo.or.cz/FilterMirrorRepo.git/blob_plain/refs/heads/master:/ListForRAssholeDesign.txt",
+    "viewUrlMirror2": "https://gitlab.com/DandelionSprout/adfilt/raw/master/ListForRAssholeDesign.txt"
+  },
+  {
+    "id": 1454,
+    "description": "This list was initially made as a kind gesture to https://github.com/theel0ja, who has been using, recommending, and promoting the lists above. This Nano- and uBO-exclusive list removes all sorts of annoying banners that few other lists take care of, including uncloseable overlays, banners that advertise major browsers, and certain banners that ask if you want to be asked to receive bad browser notifications (It makes sense in context).",
+    "descriptionSourceUrl": "https://raw.githubusercontent.com/DandelionSprout/adfilt/master/AnnoyingBannersAndOverlays.txt",
+    "donateUrl": "https://sproutsluckycorner.wordpress.com/2017/11/14/my-work-and-contact-resume/#donations",
+    "emailAddress": "imreeil42@gmail.com",
+    "homeUrl": "https://github.com/DandelionSprout/adfilt",
+    "issuesUrl": "https://github.com/DandelionSprout/adfilt/issues",
+    "licenseId": 10,
+    "name": "Dandelion Sprout's Annoying Banners and Overlays List",
+    "syntaxId": 21,
+    "viewUrl": "https://raw.githubusercontent.com/DandelionSprout/adfilt/master/AnnoyingBannersAndOverlays.txt",
+    "viewUrlMirror1": "https://repo.or.cz/FilterMirrorRepo.git/blob_plain/refs/heads/master:/AnnoyingBannersAndOverlays.txt",
+    "viewUrlMirror2": "https://gitlab.com/DandelionSprout/adfilt/raw/master/AnnoyingBannersAndOverlays.txt"
+  },
+  {
+    "id": 1455,
+    "description": "If Fanboy and AdGuard can make overly broad and imperfect 'Annoyances' lists and get included in uBlock Origin without breaking a sweat, then so can I... hopefully...",
+    "descriptionSourceUrl": "https://raw.githubusercontent.com/DandelionSprout/adfilt/master/AnnoyancesList",
+    "donateUrl": "https://sproutsluckycorner.wordpress.com/2017/11/14/my-work-and-contact-resume/#donations",
+    "emailAddress": "imreeil42@gmail.com",
+    "homeUrl": "https://github.com/DandelionSprout/adfilt",
+    "issuesUrl": "https://github.com/DandelionSprout/adfilt/issues",
+    "licenseId": 10,
+    "name": "Dandelion Sprout's Annoyances List",
+    "syntaxId": 21,
+    "viewUrl": "https://raw.githubusercontent.com/DandelionSprout/adfilt/master/AnnoyancesList",
+    "viewUrlMirror1": "https://repo.or.cz/FilterMirrorRepo.git/blob_plain/refs/heads/master:/AnnoyancesList",
+    "viewUrlMirror2": "https://gitlab.com/DandelionSprout/adfilt/raw/master/AnnoyancesList"
+  },
+  {
+    "id": 1456,
+    "description": "This list aims to achieve pretty broad (if not overly broad) coverage of social sharing buttons, with perhaps 1/50th~1/100th as many entries as what the biggest anti-'social button' lists out there have.",
+    "descriptionSourceUrl": "https://raw.githubusercontent.com/DandelionSprout/adfilt/master/SocialShareList.txt",
+    "donateUrl": "https://sproutsluckycorner.wordpress.com/2017/11/14/my-work-and-contact-resume/#donations",
+    "emailAddress": "imreeil42@gmail.com",
+    "homeUrl": "https://github.com/DandelionSprout/adfilt",
+    "issuesUrl": "https://github.com/DandelionSprout/adfilt/issues",
+    "licenseId": 10,
+    "name": "Dandelion Sprout's Lightweight Anti-'Social share' List",
+    "syntaxId": 3,
+    "viewUrl": "https://raw.githubusercontent.com/DandelionSprout/adfilt/master/SocialShareList.txt",
+    "viewUrlMirror1": "https://repo.or.cz/FilterMirrorRepo.git/blob_plain/refs/heads/master:/SocialShareList.txt",
+    "viewUrlMirror2": "https://gitlab.com/DandelionSprout/adfilt/raw/master/SocialShareList.txt"
+  },
 ]

--- a/data/FilterList.json
+++ b/data/FilterList.json
@@ -4801,7 +4801,8 @@
     "syntaxId": 2,
     "updatedDate": "2018-10-10T21:17:10",
     "viewUrl": "https://raw.githubusercontent.com/DandelionSprout/adfilt/master/List%20for%20Chrome%20Personal%20Blocklist",
-    "viewUrlMirror1": "https://repo.or.cz/FilterMirrorRepo.git/blob_plain/refs/heads/master:/List%20for%20Chrome%20Personal%20Blocklist"
+    "viewUrlMirror1": "https://repo.or.cz/FilterMirrorRepo.git/blob_plain/refs/heads/master:/List%20for%20Chrome%20Personal%20Blocklist",
+    "viewUrlMirror2": "https://gitlab.com/DandelionSprout/adfilt/raw/master/List%20for%20Chrome%20Personal%20Blocklist"
   },
   {
     "id": 390,

--- a/data/FilterListLanguage.json
+++ b/data/FilterListLanguage.json
@@ -660,10 +660,6 @@
     "languageId": 83
   },
   {
-    "filterListId": 402,
-    "languageId": 44
-  },
-  {
     "filterListId": 416,
     "languageId": 167
   },

--- a/data/FilterListMaintainer.json
+++ b/data/FilterListMaintainer.json
@@ -616,10 +616,6 @@
     "maintainerId": 22
   },
   {
-    "filterListId": 854,
-    "maintainerId": 22
-  },
-  {
     "filterListId": 855,
     "maintainerId": 22
   },

--- a/data/FilterListMaintainer.json
+++ b/data/FilterListMaintainer.json
@@ -668,6 +668,22 @@
     "maintainerId": 22
   },
   {
+    "filterListId": 1453,
+    "maintainerId": 22
+  },
+  {
+    "filterListId": 1454,
+    "maintainerId": 22
+  },
+  {
+    "filterListId": 1455,
+    "maintainerId": 22
+  },
+  {
+    "filterListId": 1456,
+    "maintainerId": 22
+  },
+  {
     "filterListId": 21,
     "maintainerId": 23
   },

--- a/data/FilterListMaintainer.json
+++ b/data/FilterListMaintainer.json
@@ -3404,27 +3404,11 @@
     "maintainerId": 109
   },
   {
-    "filterListId": 1131,
-    "maintainerId": 109
-  },
-  {
-    "filterListId": 1132,
-    "maintainerId": 109
-  },
-  {
     "filterListId": 1133,
     "maintainerId": 109
   },
   {
-    "filterListId": 1134,
-    "maintainerId": 109
-  },
-  {
     "filterListId": 1135,
-    "maintainerId": 109
-  },
-  {
-    "filterListId": 1136,
     "maintainerId": 109
   },
   {
@@ -3509,10 +3493,6 @@
   },
   {
     "filterListId": 1162,
-    "maintainerId": 109
-  },
-  {
-    "filterListId": 1163,
     "maintainerId": 109
   },
   {
@@ -3625,14 +3605,6 @@
   },
   {
     "filterListId": 1199,
-    "maintainerId": 109
-  },
-  {
-    "filterListId": 1200,
-    "maintainerId": 109
-  },
-  {
-    "filterListId": 1201,
     "maintainerId": 109
   },
   {

--- a/data/FilterListTag.json
+++ b/data/FilterListTag.json
@@ -5821,19 +5821,11 @@
   },
   {
     "filterListId": 1305,
-    "tagId": 3
-  },
-  {
-    "filterListId": 1305,
-    "tagId": 6
+    "tagId": 2
   },
   {
     "filterListId": 1306,
-    "tagId": 3
-  },
-  {
-    "filterListId": 1306,
-    "tagId": 6
+    "tagId": 2
   },
   {
     "filterListId": 1307,
@@ -6189,19 +6181,11 @@
   },
   {
     "filterListId": 1351,
-    "tagId": 3
-  },
-  {
-    "filterListId": 1351,
-    "tagId": 6
+    "tagId": 17
   },
   {
     "filterListId": 1352,
-    "tagId": 3
-  },
-  {
-    "filterListId": 1352,
-    "tagId": 6
+    "tagId": 17
   },
   {
     "filterListId": 1353,
@@ -6781,19 +6765,11 @@
   },
   {
     "filterListId": 1425,
-    "tagId": 3
-  },
-  {
-    "filterListId": 1425,
-    "tagId": 6
+    "tagId": 11
   },
   {
     "filterListId": 1426,
-    "tagId": 3
-  },
-  {
-    "filterListId": 1426,
-    "tagId": 6
+    "tagId": 11
   },
   {
     "filterListId": 1427,

--- a/data/FilterListTag.json
+++ b/data/FilterListTag.json
@@ -6978,5 +6978,21 @@
   {
     "filterListId": 1452,
     "tagId": 6
+  },
+  {
+    "filterListId": 1453,
+    "tagId": 9
+  },
+  {
+    "filterListId": 1454,
+    "tagId": 9
+  },
+  {
+    "filterListId": 1455,
+    "tagId": 9
+  },
+  {
+    "filterListId": 1456,
+    "tagId": 4
   }
 ]

--- a/data/FilterListTag.json
+++ b/data/FilterListTag.json
@@ -1912,10 +1912,6 @@
     "tagId": 6
   },
   {
-    "filterListId": 402,
-    "tagId": 10
-  },
-  {
     "filterListId": 403,
     "tagId": 15
   },
@@ -3970,10 +3966,6 @@
   {
     "filterListId": 853,
     "tagId": 9
-  },
-  {
-    "filterListId": 854,
-    "tagId": 10
   },
   {
     "filterListId": 855,

--- a/data/FilterListTag.json
+++ b/data/FilterListTag.json
@@ -5092,27 +5092,11 @@
     "tagId": 6
   },
   {
-    "filterListId": 1131,
-    "tagId": 11
-  },
-  {
-    "filterListId": 1132,
-    "tagId": 11
-  },
-  {
     "filterListId": 1133,
     "tagId": 14
   },
   {
-    "filterListId": 1134,
-    "tagId": 2
-  },
-  {
     "filterListId": 1135,
-    "tagId": 2
-  },
-  {
-    "filterListId": 1136,
     "tagId": 2
   },
   {
@@ -5193,10 +5177,6 @@
   },
   {
     "filterListId": 1162,
-    "tagId": 2
-  },
-  {
-    "filterListId": 1163,
     "tagId": 2
   },
   {
@@ -5309,14 +5289,6 @@
   },
   {
     "filterListId": 1199,
-    "tagId": 2
-  },
-  {
-    "filterListId": 1200,
-    "tagId": 2
-  },
-  {
-    "filterListId": 1201,
     "tagId": 2
   },
   {

--- a/data/SoftwareSyntax.json
+++ b/data/SoftwareSyntax.json
@@ -214,5 +214,13 @@
   {
     "softwareId": 23,
     "syntaxId": 20
+  },
+  {
+    "softwareId": 1,
+    "syntaxId": 21
+  },
+  {
+    "softwareId": 5,
+    "syntaxId": 21
   }
 ]

--- a/data/Syntax.json
+++ b/data/Syntax.json
@@ -89,7 +89,7 @@
   },
   {
     "id": 21,
-    "definitionUrl": "https://github.com/gorhill/uBlock/wiki/Static-filter-syntax#include-file-name"
+    "definitionUrl": "https://github.com/gorhill/uBlock/wiki/Static-filter-syntax#include-file-name",
     "name": "uBlock Origin !#include-tag compilation"
   }
 ]

--- a/data/Syntax.json
+++ b/data/Syntax.json
@@ -86,5 +86,9 @@
   {
     "id": 20,
     "name": "dnsmasq domains list"
+  },
+  {
+    "id": 21,
+    "name": "uBlock Origin !#include-tag compilation"
   }
 ]

--- a/data/Syntax.json
+++ b/data/Syntax.json
@@ -89,6 +89,7 @@
   },
   {
     "id": 21,
+    "definitionUrl": "https://github.com/gorhill/uBlock/wiki/Static-filter-syntax#include-file-name"
     "name": "uBlock Origin !#include-tag compilation"
   }
 ]


### PR DESCRIPTION
A fair bit of maintenance.

* Added my 4 newest lists.
* Added a new syntax, for lists that are solely compilations of other lists through `#!include`. This was necessary to add, since AdGuard does not seem to me to support `!#include` in non-included lists.
* Changed the tags of 6 Shalla lists.
* Added a GitLab mirror for all of my 43 lists.
* Removed 2 lists: *Evidon Unbreaker* (Discontinued and deleted), and *Startshop ABP Filters* (The cashback service took their remaining money and ran, allowing their domain to expire).
* Updated the link to *Raajje-AdList*.
* Removed 5 lists by Deathbybandaid (and turned 2 others into mirrors of other lists), as they were domain versions of lists that were already domains-lists to begin with, and had fewer entries than the original lists as well.
* A small handful of grammar corrections and updates.