### PR TITLE
Patch 68

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -32,7 +32,7 @@ Typical adblockers run as an extension in popular web browsers. As we browse the
   - Imre Kristoffer Eilertsen [@DandelionSprout](https://github.com/DandelionSprout) : major contributor
   - Raymond Hill [@gorhill](https://github.com/gorhill) : uBlock Origin owner, advised on some technical aspects of FilterLists
   - Andrey Meshkov [@ameshkov](https://github.com/ameshkov) : AdGuard CTO, advised on some technical aspects of FilterLists
-  - [More Contributors](https://github.com/collinbarrett/FilterLists/graphs/contributors)
+  - [More contributors](https://github.com/collinbarrett/FilterLists/graphs/contributors)
 
 ## Miscellany
 

--- a/data/Syntax.json
+++ b/data/Syntax.json
@@ -26,7 +26,7 @@
   {
     "id": 7,
     "definitionUrl": "https://github.com/gorhill/uBlock/wiki/Dynamic-filtering:-quick-guide",
-    "name": "uBlock Origin/uMatrix Dynamic"
+    "name": "uMatrix / uBlock Origin Dynamic"
   },
   {
     "id": 8,


### PR DESCRIPTION
Emergency pull to try to bump the current recentmost edit off the front page of the GitHub repo. Related to `https://github.com/collinbarrett/FilterLists/pull/711#issuecomment-471125105`.