### PR TITLE
Add filter list “Hello, Goodbye!”

### DIFF
--- a/data/FilterList.json
+++ b/data/FilterList.json
@@ -16333,5 +16333,14 @@
     "name": "KoreanList",
     "syntaxId": 3,
     "viewUrl": "https://easylist-downloads.adblockplus.org/koreanlist.txt"
+  },
+  {
+    "id": 1530,
+    "viewUrl": "https://raw.githubusercontent.com/bcye/Hello-Goodbye/master/filterlist.txt",
+    "name": "Hello, Goodbye!",
+    "description": "Blocks every chat or helpdesk pop up in your browser.",
+    "homeUrl": "https://hellogoodbye.app/",
+    "issuesUrl": "https://github.com/bcye/Hello-Goodbye/issues",
+    "emailAddress": "hello@hellogoodbye.app"
   }
 ]

--- a/data/FilterListTag.json
+++ b/data/FilterListTag.json
@@ -6962,5 +6962,13 @@
   {
     "filterListId": 1529,
     "tagId": 2
+  },
+  {
+    "filterListId": 1530,
+    "tagId": 9
+  },
+  {
+    "filterListId": 1530,
+    "tagId": 16
   }
 ]


### PR DESCRIPTION
This adds the [Hello, Goodbye!](https://hellogoodbye.app/) filter list, which the author extracted two days ago from their Chrome extension and Firefox add-on.

What I added to `FilterList.json`:

- `id`: 1530
- `viewUrl`: https://raw.githubusercontent.com/bcye/Hello-Goodbye/master/filterlist.txt
- `name`: Hello, Goodbye!
- `description`: Blocks every chat or helpdesk pop up in your browser.
- `emailAddress`: hello@hellogoodbye.app
- `homeUrl`: https://hellogoodbye.app/
- `issuesUrl`: https://github.com/bcye/Hello-Goodbye/issues

I didn’t set `syntax` because I’m not sure how to tell which syntax it is. From the examples on the [Syntax page](https://github.com/collinbarrett/FilterLists/wiki/Syntax), it looks to be closest to Adblock Plus format because of the leading `||`, but the list works with uBlock Origin, so is it really Adblock Plus?

The tag IDs I linked in `FilterListTag.json`:

- `9` (annoyances)
- `16` (overlay)