### PR TITLE
Date formatting, take 3

### DIFF
--- a/src/FilterLists.Web/ClientApp/modules/home/components/detailsExpander/infoCard/UpdatedDate.tsx
+++ b/src/FilterLists.Web/ClientApp/modules/home/components/detailsExpander/infoCard/UpdatedDate.tsx
@@ -9,7 +9,7 @@ export const UpdatedDate = (props: IProps) =>
     props.updatedDate
     ? <li className="list-group-item">
           <p>Updated: {moment(props.updatedDate).isValid()
-                           ? moment(props.updatedDate).local().format("l")
+                           ? moment(props.updatedDate).format("l").toLocaleString()
                            : "N/A"}</p>
       </li>
     : null;


### PR DESCRIPTION
At least the update dates were showing up again after the last pull, but they were still US-format-only.

But after discovering that `.toLocaleString()` has been successfully used for [the rule counter on the top of the page](https://github.com/collinbarrett/FilterLists/blob/master/src/FilterLists.Web/ClientApp/modules/home/components/Oneliner.tsx), I'll try it out for dates as well.