### PR TITLE
Date formatting, take 5

### DIFF
--- a/src/FilterLists.Web/ClientApp/modules/home/components/detailsExpander/infoCard/UpdatedDate.tsx
+++ b/src/FilterLists.Web/ClientApp/modules/home/components/detailsExpander/infoCard/UpdatedDate.tsx
@@ -1,5 +1,4 @@
 import * as React from "react";
-import * as moment from "moment";
 
 interface IProps {
     updatedDate: string;
@@ -8,8 +7,6 @@ interface IProps {
 export const UpdatedDate = (props: IProps) =>
     props.updatedDate
     ? <li className="list-group-item">
-          <p>Updated: {moment(props.updatedDate.toLocaleString()).isValid()
-                           ? moment(props.updatedDate.toLocaleString()).format("l")
-                           : "N/A"}</p>
+          <p>Updated: {props.updatedDate.toLocaleString()}</p>
       </li>
     : null;


### PR DESCRIPTION
If `{props.ruleCount.toLocaleString()}` works in https://github.com/collinbarrett/FilterLists/blob/master/src/FilterLists.Web/ClientApp/modules/home/components/detailsExpander/infoCard/RuleCount.tsx, then surely `{props.updatedDate.toLocaleString()}` would have to work for dates as well, hopefully...
