### PR TITLE
Reverting the date formatting

### DIFF
--- a/src/FilterLists.Web/ClientApp/modules/home/components/detailsExpander/infoCard/UpdatedDate.tsx
+++ b/src/FilterLists.Web/ClientApp/modules/home/components/detailsExpander/infoCard/UpdatedDate.tsx
@@ -1,12 +1,13 @@
-import * as React from "react";
+    import * as React from "react";
+import * as moment from "moment";
 
 interface IProps {
-    updatedDate: date;
+    updatedDate: string;
 };
 
 export const UpdatedDate = (props: IProps) =>
     props.updatedDate
     ? <li className="list-group-item">
-          <p>Updated: {props.updatedDate.toLocaleDateString()}</p>
+          <p>Updated: {moment(props.updatedDate).locale().format("l")</p>
       </li>
     : null;

--- a/src/FilterLists.Web/ClientApp/modules/home/components/detailsExpander/infoCard/UpdatedDate.tsx
+++ b/src/FilterLists.Web/ClientApp/modules/home/components/detailsExpander/infoCard/UpdatedDate.tsx
@@ -8,6 +8,6 @@ interface IProps {
 export const UpdatedDate = (props: IProps) =>
     props.updatedDate
     ? <li className="list-group-item">
-          <p>Updated: {moment(props.updatedDate).locale().format("l")</p>
+          <p>Updated: {moment(props.updatedDate).locale().format("l")}</p>
       </li>
     : null;

--- a/src/FilterLists.Web/ClientApp/modules/home/components/detailsExpander/infoCard/UpdatedDate.tsx
+++ b/src/FilterLists.Web/ClientApp/modules/home/components/detailsExpander/infoCard/UpdatedDate.tsx
@@ -7,6 +7,6 @@ interface IProps {
 export const UpdatedDate = (props: IProps) =>
     props.updatedDate
     ? <li className="list-group-item">
-          <p>Updated: {props.updatedDate.format("l").toLocaleString()}</p>
+          <p>Updated: {props.updatedDate.toLocaleDateString()}</p>
       </li>
     : null;

--- a/src/FilterLists.Web/ClientApp/modules/home/components/detailsExpander/infoCard/UpdatedDate.tsx
+++ b/src/FilterLists.Web/ClientApp/modules/home/components/detailsExpander/infoCard/UpdatedDate.tsx
@@ -7,6 +7,6 @@ interface IProps {
 export const UpdatedDate = (props: IProps) =>
     props.updatedDate
     ? <li className="list-group-item">
-          <p>Updated: {props.updatedDate.toLocaleString()}</p>
+          <p>Updated: {props.updatedDate.format("l").toLocaleString()}</p>
       </li>
     : null;

--- a/src/FilterLists.Web/ClientApp/modules/home/components/detailsExpander/infoCard/UpdatedDate.tsx
+++ b/src/FilterLists.Web/ClientApp/modules/home/components/detailsExpander/infoCard/UpdatedDate.tsx
@@ -1,4 +1,4 @@
-    import * as React from "react";
+import * as React from "react";
 import * as moment from "moment";
 
 interface IProps {
@@ -9,7 +9,7 @@ export const UpdatedDate = (props: IProps) =>
     props.updatedDate
     ? <li className="list-group-item">
           <p>Updated: {moment(props.updatedDate).isValid()
-                       ? moment(props.updatedDate).locale().format("l")
-                       : "N/A"}</p>
+                           ? moment(props.updatedDate).format("l")
+                           : "N/A"}</p>
       </li>
     : null;

--- a/src/FilterLists.Web/ClientApp/modules/home/components/detailsExpander/infoCard/UpdatedDate.tsx
+++ b/src/FilterLists.Web/ClientApp/modules/home/components/detailsExpander/infoCard/UpdatedDate.tsx
@@ -8,6 +8,8 @@ interface IProps {
 export const UpdatedDate = (props: IProps) =>
     props.updatedDate
     ? <li className="list-group-item">
-          <p>Updated: {moment(props.updatedDate).locale().format("l")}</p>
+          <p>Updated: {moment(props.updatedDate).isValid()
+                       ? moment(props.updatedDate).locale().format("l")
+                       : "N/A"}</p>
       </li>
     : null;

--- a/src/FilterLists.Web/ClientApp/modules/home/components/detailsExpander/infoCard/UpdatedDate.tsx
+++ b/src/FilterLists.Web/ClientApp/modules/home/components/detailsExpander/infoCard/UpdatedDate.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 
 interface IProps {
-    updatedDate: string;
+    updatedDate: date;
 };
 
 export const UpdatedDate = (props: IProps) =>


### PR DESCRIPTION
Contrary to how it may have looked like, take 5 was not a failure, as I learned from it that MomentJS is in fact not mandatory in order to display dates.

Although take 5 did make the dates display their full UTC timestamps á la `Updated: 2019-02-11T08:56:09`, so now comes the fine-tuning part.
