### PR TITLE
Mid-April pull

### DIFF
--- a/data/FilterList.json
+++ b/data/FilterList.json
@@ -8081,7 +8081,7 @@
     "id": 755,
     "homeUrl": "http://jansal.net/TPL.shtml",
     "licenseId": 5,
-    "name": "M",
+    "name": "Sucuri M",
     "syntaxId": 10,
     "updatedDate": "2013-12-28T00:00:00",
     "viewUrl": "http://jansal.net/tpl/m.tpl"
@@ -12298,17 +12298,6 @@
     "viewUrl": "https://raw.githubusercontent.com/deathbybandaid/piholeparser/master/Subscribable-Lists/ParsedBlacklists/BreakingTheNews.txt"
   },
   {
-    "id": 1129,
-    "homeUrl": "https://github.com/deathbybandaid/piholeparser",
-    "issuesUrl": "https://github.com/deathbybandaid/piholeparser/issues",
-    "licenseId": 14,
-    "name": "Bulgarian List (Domains)",
-    "publishedDate": "2017-09-02T01:07:36",
-    "syntaxId": 2,
-    "updatedDate": "2019-02-01T00:40:14",
-    "viewUrl": "https://raw.githubusercontent.com/deathbybandaid/piholeparser/master/Subscribable-Lists/ParsedBlacklists/BulgarianListEasyList.txt"
-  },
-  {
     "id": 1130,
     "homeUrl": "https://github.com/deathbybandaid/piholeparser",
     "issuesUrl": "https://github.com/deathbybandaid/piholeparser/issues",
@@ -13663,7 +13652,7 @@
     "updatedDate": "2019-03-27T21:25:33+00:00",
     "viewUrl": "https://gitlab.com/intr0/DomainVoider/raw/master/DomainVoider.txt",
     "viewUrlMirror1": "https://notabug.org/-intr0/DomainVoider/raw/master/DomainVoider.txt",
-    "viewUrlMirror2": "http://vivmyccb3jdb7yij.onion/intr0/DomainVoider/raw/master/DomainVoider.txt"
+    "viewUrlMirror2": "https://vivmyccb3jdb7yij.onion/intr0/DomainVoider/raw/master/DomainVoider.txt"
   },
   {
     "id": 1297,
@@ -16606,5 +16595,35 @@
     "name": "Fuck Fuckadblock",
     "syntaxId": 4,
     "viewUrl": "https://raw.githubusercontent.com/bogachenko/fuckfuckadblock/master/fuckfuckadblock.txt"
+  },
+  {
+    "id": 1559,
+    "description": "This hosts file blocks the BBC News website Breaking News banner",
+    "descriptionSourceUrl": "https://raw.githubusercontent.com/BreakingTheNews/BreakingTheNews.github.io/master/hosts",
+    "homeUrl": "https://github.com/BreakingTheNews/BreakingTheNews.github.io",
+    "issuesUrl": "https://github.com/BreakingTheNews/BreakingTheNews.github.io/issues",
+    "name": "Breaking the News",
+    "syntaxId": 1,
+    "viewUrl": "https://raw.githubusercontent.com/BreakingTheNews/BreakingTheNews.github.io/master/hosts"
+  },
+  {
+    "id": 1560,
+    "description": "Block Bitcoin Mining in browser (webs and extensions)",
+    "descriptionSourceUrl": "https://github.com/ruvelro/Halt-and-Block-Mining/blob/master/README.md",
+    "homeUrl": "https://github.com/ruvelro/Halt-and-Block-Mining",
+    "issuesUrl": "https://github.com/ruvelro/Halt-and-Block-Mining/issues",
+    "name": "Halt-and-Block-Mining",
+    "syntaxId": 27,
+    "viewUrl": "https://raw.githubusercontent.com/ruvelro/Halt-and-Block-Mining/master/HBmining.bat"
+  },
+  {
+    "id": 1561,
+    "description": "A list of 400+ Admiral domains. These are provided for educational and research purposes only.",
+    "descriptionSourceUrl": "https://github.com/jkrejcha/AdmiraList/",
+    "homeUrl": "https://github.com/jkrejcha/AdmiraList/",
+    "issuesUrl": "https://github.com/jkrejcha/AdmiraList/issues",
+    "name": "AdmiraList",
+    "syntaxId": 2,
+    "viewUrl": "https://raw.githubusercontent.com/jkrejcha/AdmiraList/master/AdmiraList.txt"
   }
 ]

--- a/data/FilterListLanguage.json
+++ b/data/FilterListLanguage.json
@@ -1756,10 +1756,6 @@
     "languageId": 141
   },
   {
-    "filterListId": 1129,
-    "languageId": 113
-  },
-  {
     "filterListId": 1143,
     "languageId": 75
   },
@@ -2090,5 +2086,13 @@
   {
     "filterListId": 1555,
     "languageId": 179
+  },
+  {
+    "filterListId": 1239,
+    "languageId": 167
+  },
+  {
+    "filterListId": 769,
+    "languageId": 163
   }
 ]

--- a/data/FilterListMaintainer.json
+++ b/data/FilterListMaintainer.json
@@ -3196,10 +3196,6 @@
     "maintainerId": 109
   },
   {
-    "filterListId": 1129,
-    "maintainerId": 109
-  },
-  {
     "filterListId": 1130,
     "maintainerId": 109
   },

--- a/data/FilterListTag.json
+++ b/data/FilterListTag.json
@@ -161,7 +161,7 @@
   },
   {
     "filterListId": 38,
-    "tagId": 15
+    "tagId": 29
   },
   {
     "filterListId": 39,
@@ -169,7 +169,7 @@
   },
   {
     "filterListId": 40,
-    "tagId": 15
+    "tagId": 7
   },
   {
     "filterListId": 41,
@@ -2621,7 +2621,7 @@
   },
   {
     "filterListId": 607,
-    "tagId": 9
+    "tagId": 28
   },
   {
     "filterListId": 608,
@@ -2825,7 +2825,7 @@
   },
   {
     "filterListId": 660,
-    "tagId": 9
+    "tagId": 28
   },
   {
     "filterListId": 661,
@@ -3301,7 +3301,7 @@
   },
   {
     "filterListId": 769,
-    "tagId": 15
+    "tagId": 28
   },
   {
     "filterListId": 770,
@@ -4856,10 +4856,6 @@
     "tagId": 2
   },
   {
-    "filterListId": 1129,
-    "tagId": 2
-  },
-  {
     "filterListId": 1130,
     "tagId": 6
   },
@@ -4961,7 +4957,7 @@
   },
   {
     "filterListId": 1166,
-    "tagId": 15
+    "tagId": 29
   },
   {
     "filterListId": 1167,
@@ -5013,7 +5009,7 @@
   },
   {
     "filterListId": 1184,
-    "tagId": 5
+    "tagId": 8
   },
   {
     "filterListId": 1185,
@@ -5397,11 +5393,7 @@
   },
   {
     "filterListId": 1304,
-    "tagId": 14
-  },
-  {
-    "filterListId": 1304,
-    "tagId": 15
+    "tagId": 27
   },
   {
     "filterListId": 1305,
@@ -5485,11 +5477,11 @@
   },
   {
     "filterListId": 1323,
-    "tagId": 15
+    "tagId": 7
   },
   {
     "filterListId": 1324,
-    "tagId": 15
+    "tagId": 7
   },
   {
     "filterListId": 1325,
@@ -5925,11 +5917,11 @@
   },
   {
     "filterListId": 1433,
-    "tagId": 15
+    "tagId": 3
   },
   {
     "filterListId": 1434,
-    "tagId": 15
+    "tagId": 3
   },
   {
     "filterListId": 1435,
@@ -5949,7 +5941,7 @@
   },
   {
     "filterListId": 1440,
-    "tagId": 15
+    "tagId": 11
   },
   {
     "filterListId": 1441,
@@ -5969,19 +5961,19 @@
   },
   {
     "filterListId": 1445,
-    "tagId": 15
+    "tagId": 4
   },
   {
     "filterListId": 1446,
-    "tagId": 15
+    "tagId": 4
   },
   {
     "filterListId": 1447,
-    "tagId": 15
+    "tagId": 4
   },
   {
     "filterListId": 1448,
-    "tagId": 15
+    "tagId": 4
   },
   {
     "filterListId": 1449,
@@ -6461,11 +6453,7 @@
   },
   {
     "filterListId": 1530,
-    "tagId": 9
-  },
-  {
-    "filterListId": 1530,
-    "tagId": 16
+    "tagId": 29
   },
   {
     "filterListId": 1531,
@@ -6565,7 +6553,7 @@
   },
   {
     "filterListId": 1439,
-    "tagId": 15
+    "tagId": 11
   },
   {
     "filterListId": 1160,
@@ -6585,7 +6573,7 @@
   },
   {
     "filterListId": 1552,
-    "tagId": 25
+    "tagId": 15
   },
   {
     "filterListId": 1550,
@@ -6626,5 +6614,21 @@
   {
     "filterListId": 1558,
     "tagId": 5
+  },
+  {
+    "filterListId": 1559,
+    "tagId": 21
+  },
+  {
+    "filterListId": 1560,
+    "tagId": 1
+  },
+  {
+    "filterListId": 1561,
+    "tagId": 5
+  },
+  {
+    "filterListId": 1561,
+    "tagId": 14
   }
 ]

--- a/data/Syntax.json
+++ b/data/Syntax.json
@@ -111,5 +111,9 @@
   {
     "id": 26,
     "name": "BIND"
+  },
+  {
+    "id": 27,
+    "name": "Windows command line script"
   }
 ]

--- a/data/Tag.json
+++ b/data/Tag.json
@@ -133,5 +133,15 @@
     "id": 27,
     "description": "Userstyles in adblocker syntax that change the appearance of sites",
     "name": "userstyle"
+  },
+  {
+    "id": 28,
+    "description": "Blocks requests that ask you to subscribe to newsletters",
+    "name": "newsletters"
+  },
+  {
+    "id": 29,
+    "description": "Prevents \"How can I help you?\" prompts from popping up",
+    "name": "helpprompt"
   }
 ]


### PR DESCRIPTION
This pull is a bit more down-to-earth than my code-editing attempts two weeks ago, and hopefully shouldn't be able to go awry. If I remember correctly:

* Removed *Bulgarian List (Domains)*, IIRC for being an inferior version of *ABP Bulgarian List (Domains)*.
* Added 3 new lists: *Breaking the News*, *Halt-and-Block-Mining*, and *AdmiraList*.
* Added 2 new tags: `newsletter` and `helpprompt`. I was unsure if "helpprompt" should be spelt as 1 word, but I went with it for now.
* Added 1 new syntax: Windows command line script.
* Switched some tag and language assignments around.
* And a few other miniscule edits.

I also recommend that the following example be added for "Windows command line script" on [the syntax wiki page]( https://github.com/collinbarrett/FilterLists/wiki/Syntax): `echo 0.0.0.0 example.com >> %hostspath%`