### PR TITLE
Not uBO compatible, not simple domains

### DIFF
--- a/data/FilterList.json
+++ b/data/FilterList.json
@@ -15861,7 +15861,6 @@
     "homeUrl": "https://osint.bambenekconsulting.com/feeds/",
     "licenseId": 21,
     "name": "DGA domains",
-    "syntaxId": 2,
     "updatedDate": "2019-04-21T05:16:10",
     "viewUrl": "https://osint.bambenekconsulting.com/feeds/dga-feed.txt"
   },


### PR DESCRIPTION
Looks like general purpose csv. Comma separated list with domain, description, date, source(?).

[Malvaredomains.com](http://mirror1.malwaredomains.com/files/domains.txt) list is similar, but TAB separated, and columns are described in the header:

`##	nextvalidation	domain	type	original_reference-why_it_was_listed`