### PR TITLE
Hotfix for Blokada and DNS66

### DIFF
--- a/data/SoftwareSyntax.json
+++ b/data/SoftwareSyntax.json
@@ -60,6 +60,10 @@
     "syntaxId": 2
   },
   {
+    "softwareId": 4,
+    "syntaxId": 2
+  },
+  {
     "softwareId": 5,
     "syntaxId": 2
   },
@@ -81,6 +85,10 @@
   },
   {
     "softwareId": 25,
+    "syntaxId": 2
+  },
+  {
+    "softwareId": 26,
     "syntaxId": 2
   },
   {


### PR DESCRIPTION
Much to my surprise, some testing with sandbox lists of mine led me to discover that Blokada (and DNS66) really does support domains lists after all, and not just hosts files.

While I do still update #851 with things to do even after its de jure closure, this pull is meant as something a bit more hasteful and specific before I go to bed.