### PR TITLE
Hotfix for #974

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -153,4 +153,4 @@ We respect your privacy. That is the whole point of this project. The only minor
 
 ## Internet Explorer
 
-FilterLists does not support Internet Explorer. To view a smaller, TPL-only archive with subscribable links, right-click on [this link](https://raw.githubusercontent.com/collinbarrett/FilterLists/master/data/TPLSubscriptionAssistant.html), choose to save it as an HTML file, and open it in Internet Explorer ≥9.
+FilterLists does not support Internet Explorer. To view a smaller, TPL-only archive with subscribable links, visit [this page](https://raw.githack.com/collinbarrett/FilterLists/master/data/TPLSubscriptionAssistant.html).

--- a/data/TPLSubscriptionAssistant.html
+++ b/data/TPLSubscriptionAssistant.html
@@ -1,10 +1,10 @@
-Because FilterLists.com cannot be loaded in Internet Explorer, and because GitHub does not allow JavaScript links, here's a workaround to assist in subscribing to TPL lists.<br><br>
+Because FilterLists.com cannot be loaded in Internet Explorer, here's a workaround to assist in subscribing to TPL lists.<br><br>
 
 How this works:<br>
 1) Save this file as an HTML file. (This can be done by e.g. right-clicking on the raw file and saving, or by pasting it into a notepad and saving it there.)<br>
 2) Open the saved HTML file in Internet Explorer.<br>
 3) Click on a link to subscribe to it.<br>
-3.5) Normally the link will be blocked the first time around. If so, click on "Allow Blocked Content" in the resulting prompt below, and then click the link again.<br><br>
+3.5) In some circumstances, the link will be blocked the first time around. If so, click on "Allow Blocked Content" in the resulting prompt below, and then click the link again.<br><br>
 
 -------------------------------------------------------<br><br>
 

--- a/data/TPLSubscriptionAssistant.html
+++ b/data/TPLSubscriptionAssistant.html
@@ -1,6 +1,9 @@
 <!DOCTYPE html>
-<title>FilterLists.com for Internet Explorer</title>
-
+<html>
+<head>
+  <title>FilterLists.com for Internet Explorer</title>
+</head>
+<body>
 Because FilterLists.com cannot be loaded in Internet Explorer, here's a workaround to assist in subscribing to TPL lists.<br><br>
 
 In some circumstances, the link will be blocked the first time around. If so, click on "Allow Blocked Content" in the resulting prompt below, and then click the link again.<br><br>
@@ -75,3 +78,5 @@ In some circumstances, the link will be blocked the first time around. If so, cl
 (2015) <a href="javascript:window.external.msAddTrackingProtectionList('https://raw.githubusercontent.com/wiltteri/subscriptions/master/wiltteri.tpl', 'Wiltteri')">Wiltteri</a> - <a href="https://easylist-msie.adblockplus.org/wiltteri+easylist.tpl">View ruleset</a><br>
 (2015) <a href="javascript:window.external.msAddTrackingProtectionList('https://easylist-msie.adblockplus.org/wiltteri+easylist.tpl', 'Wiltteri + EasyList')">Wiltteri + EasyList</a> - <a href="https://easylist-msie.adblockplus.org/wiltteri+easylist.tpl">View ruleset</a><br>
 (2015) <a href="javascript:window.external.msAddTrackingProtectionList('https://raw.githubusercontent.com/wiltteri/subscriptions/master/wiltteri-reborn.tpl', 'Wiltteri Reborn')">Wiltteri Reborn</a> - <a href="https://raw.githubusercontent.com/wiltteri/subscriptions/master/wiltteri-reborn.tpl">View ruleset</a>
+</body>
+</html>

--- a/data/TPLSubscriptionAssistant.html
+++ b/data/TPLSubscriptionAssistant.html
@@ -1,11 +1,7 @@
 <!DOCTYPE html>
 Because FilterLists.com cannot be loaded in Internet Explorer, here's a workaround to assist in subscribing to TPL lists.<br><br>
 
-How this works:<br>
-1) Save this file as an HTML file. (This can be done by e.g. right-clicking on the raw file and saving, or by pasting it into a notepad and saving it there.)<br>
-2) Open the saved HTML file in Internet Explorer.<br>
-3) Click on a link to subscribe to it.<br>
-3.5) In some circumstances, the link will be blocked the first time around. If so, click on "Allow Blocked Content" in the resulting prompt below, and then click the link again.<br><br>
+In some circumstances, the link will be blocked the first time around. If so, click on "Allow Blocked Content" in the resulting prompt below, and then click the link again.<br><br>
 
 -------------------------------------------------------<br><br>
 

--- a/data/TPLSubscriptionAssistant.html
+++ b/data/TPLSubscriptionAssistant.html
@@ -1,10 +1,6 @@
 <!DOCTYPE html>
+<title>FilterLists.com for Internet Explorer</title>
 
-<head>
-  <title>FilterLists.com for Internet Explorer</title>
-</head>
-
-<body>
 Because FilterLists.com cannot be loaded in Internet Explorer, here's a workaround to assist in subscribing to TPL lists.<br><br>
 
 In some circumstances, the link will be blocked the first time around. If so, click on "Allow Blocked Content" in the resulting prompt below, and then click the link again.<br><br>
@@ -79,4 +75,3 @@ In some circumstances, the link will be blocked the first time around. If so, cl
 (2015) <a href="javascript:window.external.msAddTrackingProtectionList('https://raw.githubusercontent.com/wiltteri/subscriptions/master/wiltteri.tpl', 'Wiltteri')">Wiltteri</a> - <a href="https://easylist-msie.adblockplus.org/wiltteri+easylist.tpl">View ruleset</a><br>
 (2015) <a href="javascript:window.external.msAddTrackingProtectionList('https://easylist-msie.adblockplus.org/wiltteri+easylist.tpl', 'Wiltteri + EasyList')">Wiltteri + EasyList</a> - <a href="https://easylist-msie.adblockplus.org/wiltteri+easylist.tpl">View ruleset</a><br>
 (2015) <a href="javascript:window.external.msAddTrackingProtectionList('https://raw.githubusercontent.com/wiltteri/subscriptions/master/wiltteri-reborn.tpl', 'Wiltteri Reborn')">Wiltteri Reborn</a> - <a href="https://raw.githubusercontent.com/wiltteri/subscriptions/master/wiltteri-reborn.tpl">View ruleset</a>
-</body>

--- a/data/TPLSubscriptionAssistant.html
+++ b/data/TPLSubscriptionAssistant.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 Because FilterLists.com cannot be loaded in Internet Explorer, here's a workaround to assist in subscribing to TPL lists.<br><br>
 
 How this works:<br>

--- a/data/TPLSubscriptionAssistant.html
+++ b/data/TPLSubscriptionAssistant.html
@@ -1,4 +1,10 @@
 <!DOCTYPE html>
+
+<head>
+  <title>FilterLists.com for Internet Explorer</title>
+</head>
+
+<body>
 Because FilterLists.com cannot be loaded in Internet Explorer, here's a workaround to assist in subscribing to TPL lists.<br><br>
 
 In some circumstances, the link will be blocked the first time around. If so, click on "Allow Blocked Content" in the resulting prompt below, and then click the link again.<br><br>
@@ -73,3 +79,4 @@ In some circumstances, the link will be blocked the first time around. If so, cl
 (2015) <a href="javascript:window.external.msAddTrackingProtectionList('https://raw.githubusercontent.com/wiltteri/subscriptions/master/wiltteri.tpl', 'Wiltteri')">Wiltteri</a> - <a href="https://easylist-msie.adblockplus.org/wiltteri+easylist.tpl">View ruleset</a><br>
 (2015) <a href="javascript:window.external.msAddTrackingProtectionList('https://easylist-msie.adblockplus.org/wiltteri+easylist.tpl', 'Wiltteri + EasyList')">Wiltteri + EasyList</a> - <a href="https://easylist-msie.adblockplus.org/wiltteri+easylist.tpl">View ruleset</a><br>
 (2015) <a href="javascript:window.external.msAddTrackingProtectionList('https://raw.githubusercontent.com/wiltteri/subscriptions/master/wiltteri-reborn.tpl', 'Wiltteri Reborn')">Wiltteri Reborn</a> - <a href="https://raw.githubusercontent.com/wiltteri/subscriptions/master/wiltteri-reborn.tpl">View ruleset</a>
+</body>


### PR DESCRIPTION
(#974) Special thanks to @krystian3w for speculating on that Git fetchers (I've forgot what things like Githack are actually called) could allow HTML links.