### PR TITLE
Mid-October pull

### DIFF
--- a/data/FilterList.json
+++ b/data/FilterList.json
@@ -20195,5 +20195,19 @@
 "homeUrl": "https://github.com/javabean/dnsmasq-antispy",
 "issuesUrl": "https://github.com/javabean/dnsmasq-antispy/issues",
 "viewUrl": "https://raw.githubusercontent.com/javabean/dnsmasq-antispy/master/dnsmasq.zz-extra-servers-manual.conf"
-}
+},
+  {
+    "id": 1901,
+    "description": "This is a uBO compilation list for those who've grown very tired of how online cartoon fans and communities generally agree on sharing the same opinions on which shows to either praise as the second coming of Winston Churchill, or hate so much as to send death threats to the creators of them. If you like actually good cartoons (e.g. the comedic, preschool, and/or European ones), here's a list for you.",
+    "donateUrl": "https://sproutsluckycorner.wordpress.com/2017/11/14/my-work-and-contact-resume/#donations",
+    "emailAddress": "imreeil42@gmail.com",
+    "homeUrl": "https://github.com/DandelionSprout/adfilt",
+    "issuesUrl": "https://github.com/DandelionSprout/adfilt/issues",
+    "licenseId": 35,
+    "name": "Anti-'Cartoon Hipster' List",
+    "syntaxId": 21,
+    "viewUrl": "https://raw.githubusercontent.com/DandelionSprout/adfilt/master/NorwegianExperimentalList%20alternate%20versions/AntiCartoonHipsterList.txt",
+    "viewUrlMirror1": "https://repo.or.cz/FilterMirrorRepo.git/blob_plain/refs/heads/master:/NorwegianExperimentalList%20alternate%20versions/AntiCartoonHipsterList.txt",
+    "viewUrlMirror2": "https://gitlab.com/DandelionSprout/adfilt/raw/master/NorwegianExperimentalList%20alternate%20versions/AntiCartoonHipsterList.txt"
+  }
 ]

--- a/data/FilterList.json
+++ b/data/FilterList.json
@@ -20022,7 +20022,7 @@
 "viewUrl": "https://raw.githubusercontent.com/blocktastic/pihole/master/blocktastic.txt"
 },
 {
-"id": 1883
+"id": 1883,
 "name": "Broer ICT Blacklist Ads",
 "description": "Ad filter list by Broer ICT",
 "licenseId": 4,
@@ -20032,7 +20032,7 @@
 "viewUrl": "https://raw.githubusercontent.com/broerict/blacklists/master/ads"
 },
 {
-"id": 1884
+"id": 1884,
 "name": "Broer ICT Blacklist Malware",
 "description": "Malware filter list by Broer ICT",
 "licenseId": 4,
@@ -20042,7 +20042,7 @@
 "viewUrl": "https://raw.githubusercontent.com/broerict/blacklists/master/malware"
 },
 {
-"id": 1885
+"id": 1885,
 "name": "Broer ICT Blacklist Phishing",
 "description": "Phishing filter list by Broer ICT",
 "licenseId": 4,
@@ -20055,23 +20055,23 @@
 "id": 1886,
 "name": "Macedonian Pi-hole Blocklist",
 "description": "This is a Pi-hole list to block unwanted domains that serve ads on Macedonian websites."
-"syntaxId": 2
+"syntaxId": 2,
 "homeUrl": "https://github.com/cchevy/macedonian-pi-hole-blocklist",
 "issuesUrl": "https://github.com/cchevy/macedonian-pi-hole-blocklist/issues",
 "viewUrl": "https://raw.githubusercontent.com/cchevy/macedonian-pi-hole-blocklist/master/hosts.txt"
 },
 {
-"id": 1887
+"id": 1887,
 "name": "chrisjudk Hosts",
 "description": "This is a list of hosts I have found to be used for ads, malware, etc.",
 "licenseId": 2,
-"syntaxId": 1
+"syntaxId": 1,
 "homeUrl": "https://github.com/chrisjudk/hosts",
 "issuesUrl": "https://github.com/chrisjudk/hosts/issues",
 "viewUrl": "https://raw.githubusercontent.com/chrisjudk/hosts/master/hosts"
 },
 {
-"id": 1888
+"id": 1888,
 "name": "Custom Hosts Domain Filter for AdGuard",
 "syntaxId": 28,
 "homeUrl": "https://github.com/DavidTai780/AdGuard-Home-Private-Rules",
@@ -20079,7 +20079,7 @@
 "viewUrl": "https://raw.githubusercontent.com/DavidTai780/AdGuard-Home-Private-Rules/master/hosts.txt"
 },
 {
-"id": 1889
+"id": 1889,
 "name": "Private Ads Block List",
 "syntaxId": 28,
 "homeUrl": "https://github.com/DavidTai780/AdGuard-Home-Private-Rules",
@@ -20125,7 +20125,7 @@
 {
 "id": 1894,
 "name": "dex4k Blocklist",
-"description": "This is the "SAFE LIST" tested to not break legitimate functionality for commonly used software",
+"description": "This is the \"SAFE LIST\" tested to not break legitimate functionality for commonly used software",
 "syntaxId": 2,
 "homeUrl": "https://github.com/dex4k/dex4kblocklist",
 "issuesUrl": "https://github.com/dex4k/dex4kblocklist/issues",
@@ -20190,7 +20190,7 @@
 },
 {
 "id": 1900,
-"name": "ZZ Extra Servers Manual"
+"name": "ZZ Extra Servers Manual",
 "syntaxId": 20,
 "homeUrl": "https://github.com/javabean/dnsmasq-antispy",
 "issuesUrl": "https://github.com/javabean/dnsmasq-antispy/issues",

--- a/data/FilterList.json
+++ b/data/FilterList.json
@@ -20004,5 +20004,196 @@
     "viewUrl": "https://gitlab.com/curben/urlhaus-filter/raw/master/urlhaus-filter-hosts-online.txt",
     "viewUrlMirror1": "https://cdn.statically.io/gl/curben/urlhaus-filter/raw/master/urlhaus-filter-online.txt",
     "viewUrlMirror2": "https://glcdn.githack.com/curben/urlhaus-filter/raw/master/urlhaus-filter-online.txt"
-  }
+  },
+  {
+"id": 1881,
+"name": "pfbng Ads",
+"syntaxId": 2,
+"homeUrl": "https://github.com/angelics/pfbng",
+"issuesUrl": "https://github.com/angelics/pfbng/issues",
+"viewUrl": "https://raw.githubusercontent.com/angelics/pfbng/master/ads/ads-domain-list.txt"
+},
+{
+"id": 1882,
+"name": "Blocktastic Pi-Hole Blocklist",
+"syntaxId": 2,
+"homeUrl": "https://github.com/blocktastic/pihole",
+"issuesUrl": "https://github.com/blocktastic/pihole/issues",
+"viewUrl": "https://raw.githubusercontent.com/blocktastic/pihole/master/blocktastic.txt"
+},
+{
+"id": 1883
+"name": "Broer ICT Blacklist Ads",
+"description": "Ad filter list by Broer ICT",
+"licenseId": 4,
+"syntaxId": 2,
+"homeUrl": "https://github.com/broerict/blacklists",
+"issuesUrl": "https://github.com/broerict/blacklists/issues",
+"viewUrl": "https://raw.githubusercontent.com/broerict/blacklists/master/ads"
+},
+{
+"id": 1884
+"name": "Broer ICT Blacklist Malware",
+"description": "Malware filter list by Broer ICT",
+"licenseId": 4,
+"syntaxId": 2,
+"homeUrl": "https://github.com/broerict/blacklists",
+"issuesUrl": "https://github.com/broerict/blacklists/issues",
+"viewUrl": "https://raw.githubusercontent.com/broerict/blacklists/master/malware"
+},
+{
+"id": 1885
+"name": "Broer ICT Blacklist Phishing",
+"description": "Phishing filter list by Broer ICT",
+"licenseId": 4,
+"syntaxId": 2,
+"homeUrl": "https://github.com/broerict/blacklists",
+"issuesUrl": "https://github.com/broerict/blacklists/issues",
+"viewUrl": "https://raw.githubusercontent.com/broerict/blacklists/master/phishing"
+},
+{
+"id": 1886,
+"name": "Macedonian Pi-hole Blocklist",
+"description": "This is a Pi-hole list to block unwanted domains that serve ads on Macedonian websites."
+"syntaxId": 2
+"homeUrl": "https://github.com/cchevy/macedonian-pi-hole-blocklist",
+"issuesUrl": "https://github.com/cchevy/macedonian-pi-hole-blocklist/issues",
+"viewUrl": "https://raw.githubusercontent.com/cchevy/macedonian-pi-hole-blocklist/master/hosts.txt"
+},
+{
+"id": 1887
+"name": "chrisjudk Hosts",
+"description": "This is a list of hosts I have found to be used for ads, malware, etc.",
+"licenseId": 2,
+"syntaxId": 1
+"homeUrl": "https://github.com/chrisjudk/hosts",
+"issuesUrl": "https://github.com/chrisjudk/hosts/issues",
+"viewUrl": "https://raw.githubusercontent.com/chrisjudk/hosts/master/hosts"
+},
+{
+"id": 1888
+"name": "Custom Hosts Domain Filter for AdGuard",
+"syntaxId": 28,
+"homeUrl": "https://github.com/DavidTai780/AdGuard-Home-Private-Rules",
+"issuesUrl": "https://github.com/DavidTai780/AdGuard-Home-Private-Rules/issues",
+"viewUrl": "https://raw.githubusercontent.com/DavidTai780/AdGuard-Home-Private-Rules/master/hosts.txt"
+},
+{
+"id": 1889
+"name": "Private Ads Block List",
+"syntaxId": 28,
+"homeUrl": "https://github.com/DavidTai780/AdGuard-Home-Private-Rules",
+"issuesUrl": "https://github.com/DavidTai780/AdGuard-Home-Private-Rules/issues",
+"viewUrl": "https://raw.githubusercontent.com/DavidTai780/AdGuard-Home-Private-Rules/master/ads-block.txt"
+},
+{
+"id": 1890,
+"name": "noads.online Switzerland specific filters",
+"licenseId": 35,
+"syntaxId": 3,
+"homeUrl": "https://github.com/deletescape/noads",
+"issuesUrl": "https://github.com/deletescape/noads/issues",
+"viewUrl": "https://raw.githubusercontent.com/deletescape/noads/master/lists/add-switzerland.txt"
+},
+{
+"id": 1891,
+"name": "noads.online anti scumware list",
+"licenseId": 35,
+"syntaxId": 3,
+"homeUrl": "https://github.com/deletescape/noads",
+"issuesUrl": "https://github.com/deletescape/noads/issues",
+"viewUrl": "https://raw.githubusercontent.com/deletescape/noads/master/lists/fo-scumware.txt"
+},
+{
+"id": 1892,
+"name": "noads.online AdGuard Home Megalist",
+"licenseId": 35,
+"syntaxId": 28,
+"homeUrl": "https://github.com/deletescape/noads",
+"issuesUrl": "https://github.com/deletescape/noads/issues",
+"viewUrl": "https://lists.noads.online/lists/compilation.txt"
+},
+{
+"id": 1893,
+"name": "noads.online whitelist",
+"licenseId": 35,
+"syntaxId": 28,
+"homeUrl": "https://github.com/deletescape/noads",
+"issuesUrl": "https://github.com/deletescape/noads/issues",
+"viewUrl": "https://github.com/deletescape/noads/blob/master/lists/unbreak.txt"
+},
+{
+"id": 1894,
+"name": "dex4k Blocklist",
+"description": "This is the "SAFE LIST" tested to not break legitimate functionality for commonly used software",
+"syntaxId": 2,
+"homeUrl": "https://github.com/dex4k/dex4kblocklist",
+"issuesUrl": "https://github.com/dex4k/dex4kblocklist/issues",
+"viewUrl": "https://raw.githubusercontent.com/dex4k/dex4kblocklist/master/dex4kblocklist.txt"
+},
+{
+"id": 1895,
+"name": "dex4k Blocklist Extras",
+"description": "This is a secondary blocklist created as, although I believe the blocking to be legitimate, blocking these domains can break popular apps",
+"syntaxId": 2,
+"homeUrl": "https://github.com/dex4k/dex4kblocklist",
+"issuesUrl": "https://github.com/dex4k/dex4kblocklist/issues",
+"viewUrl": "https://raw.githubusercontent.com/dex4k/dex4kblocklist/master/dex4kblocklistextras.txt"
+},
+{
+"id": 1896,
+"name": "Additional Hosts - Adservers and Trackers",
+"description": "Blocks ads and trackers, and anything inbetween.",
+"licenseId": 2,
+"syntaxId": 2,
+"homeUrl": "https://github.com/DRSDavidSoft/additional-hosts",
+"issuesUrl": "https://github.com/DRSDavidSoft/additional-hosts/issues",
+"viewUrl": "https://raw.githubusercontent.com/DRSDavidSoft/additional-hosts/master/domains/blacklist/adservers-and-trackers.txt"
+},
+{
+"id": 1897,
+"name": "Additional Hosts - Unwanted Iranian",
+"description": "Blocks various scams and popups when visiting Iranian websites. E.g. fake Download buttons, Pop-unders, etc",
+"licenseId": 2,
+"syntaxId": 2,
+"homeUrl": "https://github.com/DRSDavidSoft/additional-hosts",
+"issuesUrl": "https://github.com/DRSDavidSoft/additional-hosts/issues",
+"viewUrl": "https://raw.githubusercontent.com/DRSDavidSoft/additional-hosts/master/domains/blacklist/unwanted-iranian.txt"
+},
+{
+"id": 1898,
+"name": "Additional Hosts - Activation",
+"description": "Blocks license verification and software activation. This list is intended to prevent products from expiring when they detect an invalid license.",
+"licenseId": 2,
+"syntaxId": 2,
+"homeUrl": "https://github.com/DRSDavidSoft/additional-hosts",
+"issuesUrl": "https://github.com/DRSDavidSoft/additional-hosts/issues",
+"viewUrl": "https://raw.githubusercontent.com/DRSDavidSoft/additional-hosts/master/domains/blacklist/unwanted-iranian.txt"
+},
+{
+"id": 1898
+"name": "Manually Spotted Trackers and Other Nuisances",
+"description": "For use in a tool like Pi-hole. Covers manually spotted trackers, marketing bullshit and other nuisances. May be considered a bit aggressive — but not too much. Shouldn't break any sites."
+"licenseId": 11,
+"syntaxId": 2,
+"homeUrl": "https://github.com/herrbischoff/trackers",
+"issuesUrl": "https://github.com/herrbischoff/trackers/issues",
+"viewUrl": "https://raw.githubusercontent.com/herrbischoff/trackers/master/trackers.txt"
+},
+{
+"id": 1899,
+"name": "Ghostery Bugs (dnsmasq)",
+"syntaxId": 20,
+"homeUrl": "https://github.com/javabean/dnsmasq-antispy",
+"issuesUrl": "https://github.com/javabean/dnsmasq-antispy/issues",
+"viewUrl": "https://raw.githubusercontent.com/javabean/dnsmasq-antispy/master/dnsmasq.ghostery_bugs.conf"
+},
+{
+"id": 1900,
+"name": "ZZ Extra Servers Manual"
+"syntaxId": 20,
+"homeUrl": "https://github.com/javabean/dnsmasq-antispy",
+"issuesUrl": "https://github.com/javabean/dnsmasq-antispy/issues",
+"viewUrl": "https://raw.githubusercontent.com/javabean/dnsmasq-antispy/master/dnsmasq.zz-extra-servers-manual.conf"
+}
 ]

--- a/data/FilterList.json
+++ b/data/FilterList.json
@@ -20054,7 +20054,7 @@
 {
 "id": 1886,
 "name": "Macedonian Pi-hole Blocklist",
-"description": "This is a Pi-hole list to block unwanted domains that serve ads on Macedonian websites."
+"description": "This is a Pi-hole list to block unwanted domains that serve ads on Macedonian websites.",
 "syntaxId": 2,
 "homeUrl": "https://github.com/cchevy/macedonian-pi-hole-blocklist",
 "issuesUrl": "https://github.com/cchevy/macedonian-pi-hole-blocklist/issues",
@@ -20171,9 +20171,9 @@
 "viewUrl": "https://raw.githubusercontent.com/DRSDavidSoft/additional-hosts/master/domains/blacklist/unwanted-iranian.txt"
 },
 {
-"id": 1898
+"id": 1898,
 "name": "Manually Spotted Trackers and Other Nuisances",
-"description": "For use in a tool like Pi-hole. Covers manually spotted trackers, marketing bullshit and other nuisances. May be considered a bit aggressive — but not too much. Shouldn't break any sites."
+"description": "For use in a tool like Pi-hole. Covers manually spotted trackers, marketing bullshit and other nuisances. May be considered a bit aggressive — but not too much. Shouldn't break any sites.",
 "licenseId": 11,
 "syntaxId": 2,
 "homeUrl": "https://github.com/herrbischoff/trackers",

--- a/data/FilterListLanguage.json
+++ b/data/FilterListLanguage.json
@@ -2494,5 +2494,25 @@
   {
     "filterListId": 1878,
     "languageId": 106
+  },
+  {
+    "filterListId": 1886,
+    "languageId": 29
+  },
+  {
+    "filterListId": 1888,
+    "languageId": 99
+  },
+  {
+    "filterListId": 1889,
+    "languageId": 99
+  },
+  {
+    "filterListId": 1890,
+    "languageId": 167
+  },
+  {
+    "filterListId": 1897,
+    "languageId": 10
   }
 ]

--- a/data/FilterListMaintainer.json
+++ b/data/FilterListMaintainer.json
@@ -880,6 +880,10 @@
     "maintainerId": 22
   },
   {
+    "filterListId": 1901,
+    "maintainerId": 22
+  },
+  {
     "filterListId": 21,
     "maintainerId": 23
   },

--- a/data/FilterListTag.json
+++ b/data/FilterListTag.json
@@ -9338,5 +9338,133 @@
   {
     "filterListId": 1878,
     "tagId": 7
+  },
+  {
+    "filterListId": 1881,
+    "tagId": 2
+  },
+  {
+    "filterListId": 1882,
+    "tagId": 3
+  },
+  {
+    "filterListId": 1881,
+    "tagId": 2
+  },
+  {
+    "filterListId": 1883,
+    "tagId": 2
+  },
+  {
+    "filterListId": 1884,
+    "tagId": 6
+  },
+  {
+    "filterListId": 1885,
+    "tagId": 7
+  },
+  {
+    "filterListId": 1886,
+    "tagId": 2
+  },
+  {
+    "filterListId": 1887,
+    "tagId": 2
+  },
+  {
+    "filterListId": 1887,
+    "tagId": 3
+  },
+  {
+    "filterListId": 1887,
+    "tagId": 6
+  },
+  {
+    "filterListId": 1888,
+    "tagId": 2
+  },
+  {
+    "filterListId": 1888,
+    "tagId": 10
+  },
+  {
+    "filterListId": 1889,
+    "tagId": 2
+  },
+  {
+    "filterListId": 1890,
+    "tagId": 2
+  },
+  {
+    "filterListId": 1891,
+    "tagId": 6
+  },
+  {
+    "filterListId": 1892,
+    "tagId": 2
+  },
+  {
+    "filterListId": 1892,
+    "tagId": 3
+  },
+  {
+    "filterListId": 1892,
+    "tagId": 6
+  },
+  {
+    "filterListId": 1893,
+    "tagId": 10
+  },
+  {
+    "filterListId": 1894,
+    "tagId": 2
+  },
+  {
+    "filterListId": 1894,
+    "tagId": 3
+  },
+  {
+    "filterListId": 1894,
+    "tagId": 6
+  },
+  {
+    "filterListId": 1895,
+    "tagId": 2
+  },
+  {
+    "filterListId": 1895,
+    "tagId": 3
+  },
+  {
+    "filterListId": 1895,
+    "tagId": 6
+  },
+  {
+    "filterListId": 1896,
+    "tagId": 2
+  },
+  {
+    "filterListId": 1896,
+    "tagId": 3
+  },
+  {
+    "filterListId": 1897,
+    "tagId": 6
+  },
+  {
+    "filterListId": 1898,
+    "tagId": 15
+  },
+  {
+    "filterListId": 1899,
+    "tagId": 3
+  },
+  {
+    "filterListId": 1900,
+    "tagId": 2
+  },
+  {
+    "filterListId": 1901,
+    "tagId": 30
   }
 ]

--- a/data/FilterListTag.json
+++ b/data/FilterListTag.json
@@ -9466,5 +9466,13 @@
   {
     "filterListId": 1901,
     "tagId": 30
+  },
+  {
+    "filterListId": 1837,
+    "tagId": 15
+  },
+  {
+    "filterListId": 1710,
+    "tagId": 6
   }
 ]


### PR DESCRIPTION
Okay, so the situation is that after *1hosts Pro* was added to FilterLists.com, which listed its sources (which the other 1hosts versions still don't), I've come to learn that its maintainer has otherworldly skills at finding new lists, leading to https://github.com/collinbarrett/FilterLists/issues/851 being 60 lists long when I started making this pull, and I only got through 18 of them for the immediate time being.

I request the permanent re-opening of that issue report, as going through the rest of them is far beyond what I'd be able to do on my own.