### PR TITLE
Remove link to rawgit.com

### DIFF
--- a/data/FilterList.json
+++ b/data/FilterList.json
@@ -877,7 +877,7 @@
     "syntaxId": 4,
     "updatedDate": "2019-04-06T19:16:00",
     "viewUrl": "https://raw.githubusercontent.com/NanoAdblocker/NanoFilters/master/NanoMirror/NanoDefender.txt",
-    "viewUrlMirror1": "https://cdn.rawgit.com/NanoAdblocker/NanoFilters/master/NanoMirror/NanoDefender.txt"
+    "viewUrlMirror1": "https://rawcdn.githack.com/NanoAdblocker/NanoFilters/master/NanoMirror/NanoDefender.txt"
   },
   {
     "id": 84,


### PR DESCRIPTION
https://rawgit.com/ is closing.
This change removes a link
to rawgit and replaces
it with one to githack instead.