### PR TITLE
Remove BOM encoding from data files

### DIFF
--- a/data/Dependent.json
+++ b/data/Dependent.json
@@ -1,4 +1,4 @@
-﻿[
+[
   {
     "dependentFilterListId": 344,
     "dependencyFilterListId": 301

--- a/data/Fork.json
+++ b/data/Fork.json
@@ -1,4 +1,4 @@
-﻿[
+[
   {
     "forkFilterListId": 350,
     "upstreamFilterListId": 12

--- a/data/License.json
+++ b/data/License.json
@@ -1,4 +1,4 @@
-﻿[
+[
   {
     "id": 1,
     "descriptionUrl": "https://creativecommons.org/licenses/by-nc-nd/4.0/",

--- a/data/Merge.json
+++ b/data/Merge.json
@@ -1,4 +1,4 @@
-﻿[
+[
   {
     "mergeFilterListId": 11,
     "upstreamFilterListId": 12

--- a/data/Syntax.json
+++ b/data/Syntax.json
@@ -1,4 +1,4 @@
-﻿[
+[
   {
     "id": 1,
     "definitionUrl": "https://en.wikipedia.org/wiki/Hosts_(file)",


### PR DESCRIPTION
BOM encoding isn't a recommended
way to encode text files on
most operating systems.
Here data files with BOM
encoding have been changed
to UTF-8 without BOM.
This makes parsing the
json files much simpler.

https://stackoverflow.com/questions/2223882/whats-the-difference-between-utf-8-and-utf-8-without-bom