### PR TITLE
add additional subscribe button for CDNs

### DIFF
--- a/web/src/components/SubscribeButtons.tsx
+++ b/web/src/components/SubscribeButtons.tsx
@@ -39,7 +39,7 @@ const MirrorButtons = (props: MirrorButtonsProps) => (
         ))
       : null}
     {props.viewUrlMirrors && props.viewUrlMirrors.length
-      ? props.viewUrl => (
+      ? props.viewUrl : (
           <SubscribeButton
             key={`GitCDN`}
             name={props.name}

--- a/web/src/components/SubscribeButtons.tsx
+++ b/web/src/components/SubscribeButtons.tsx
@@ -43,6 +43,7 @@ const MirrorButtons = (props: MirrorButtonsProps) => (
           <SubscribeButton
             key={`GitCDN`}
             name={props.name}
+            viewUrl={props.viewUrl}
             text={`Subscribe (GitCDN)`}
           />
         ))

--- a/web/src/components/SubscribeButtons.tsx
+++ b/web/src/components/SubscribeButtons.tsx
@@ -39,7 +39,7 @@ const MirrorButtons = (props: MirrorButtonsProps) => (
         ))
       : null}
     {props.viewUrlMirrors && props.viewUrlMirrors.length
-      ? props.viewUrlMirrors.map((viewUrlMirror: string, i: number) => (
+      ? props.viewUrl => (
           <SubscribeButton
             key={`GitCDN`}
             name={props.name}

--- a/web/src/components/SubscribeButtons.tsx
+++ b/web/src/components/SubscribeButtons.tsx
@@ -17,7 +17,7 @@ export const SubscribeButtons = (props: Props) =>
         viewUrl={props.viewUrl}
         text="Subscribe"
       />
-      <MirrorButtons name={props.name} viewUrlMirrors={props.viewUrlMirrors} />
+      <MirrorButtons name={props.name} viewUrlMirrors={props.viewUrlMirrors} viewUrl={props.viewUrl} />
     </>
   ) : null;
 

--- a/web/src/components/SubscribeButtons.tsx
+++ b/web/src/components/SubscribeButtons.tsx
@@ -109,7 +109,6 @@ const buildButtonProps = (name: string, viewUrl: string) => {
   if (key.includes("GitCDN")) {
     viewUrl.replace("https://raw.githubusercontent.com/", "https://gitcdn.xyz/repo/")
   }
-  )
 
   const title = `${
     prefixes.length ? prefixes.join(" | ") + " | " : ""

--- a/web/src/components/SubscribeButtons.tsx
+++ b/web/src/components/SubscribeButtons.tsx
@@ -106,8 +106,7 @@ const buildButtonProps = (name: string, viewUrl: string) => {
     message = `Subscribe to ${name} with Little Snitch's rule group subscription feature.`;
   }
   
-  if (
-    key.includes("GitCDN") {
+  if (key.includes("GitCDN")) {
     viewUrl.replace("https://raw.githubusercontent.com/", "https://gitcdn.xyz/repo/")
   }
   )

--- a/web/src/components/SubscribeButtons.tsx
+++ b/web/src/components/SubscribeButtons.tsx
@@ -38,6 +38,16 @@ const MirrorButtons = (props: MirrorButtonsProps) => (
           />
         ))
       : null}
+    {props.viewUrlMirrors && props.viewUrlMirrors.length
+      ? props.viewUrlMirrors.map((viewUrlMirror: string, i: number) => (
+          <SubscribeButton
+            key={`GitCDN`}
+            name={props.name}
+            viewUrl={viewUrl}
+            text={`Subscribe (GitCDN)`}
+          />
+        ))
+      : null}
   </>
 );
 
@@ -95,6 +105,12 @@ const buildButtonProps = (name: string, viewUrl: string) => {
     href = `x-littlesnitch:subscribe-rules?url=${hrefLocation}`;
     message = `Subscribe to ${name} with Little Snitch's rule group subscription feature.`;
   }
+  
+  if (
+    key.includes("GitCDN") {
+    viewUrl.replace("https://raw.githubusercontent.com/", "https://gitcdn.xyz/repo/")
+  }
+  )
 
   const title = `${
     prefixes.length ? prefixes.join(" | ") + " | " : ""

--- a/web/src/components/SubscribeButtons.tsx
+++ b/web/src/components/SubscribeButtons.tsx
@@ -47,7 +47,7 @@ const MirrorButtons = (props: MirrorButtonsProps) => (
             text={`Subscribe (GitCDN)`}
           />
         )
-      : null}
+      }
   </>
 );
 

--- a/web/src/components/SubscribeButtons.tsx
+++ b/web/src/components/SubscribeButtons.tsx
@@ -107,7 +107,7 @@ const buildButtonProps = (name: string, viewUrl: string) => {
     message = `Subscribe to ${name} with Little Snitch's rule group subscription feature.`;
   }
   
-  if (key.includes("GitCDN")) {
+  if (text.includes("GitCDN")) {
     viewUrl.replace("https://raw.githubusercontent.com/", "https://gitcdn.xyz/repo/")
   }
 

--- a/web/src/components/SubscribeButtons.tsx
+++ b/web/src/components/SubscribeButtons.tsx
@@ -46,7 +46,7 @@ const MirrorButtons = (props: MirrorButtonsProps) => (
             viewUrl={props.viewUrl}
             text={`Subscribe (GitCDN)`}
           />
-        }))
+        )
       : null}
   </>
 );

--- a/web/src/components/SubscribeButtons.tsx
+++ b/web/src/components/SubscribeButtons.tsx
@@ -43,7 +43,6 @@ const MirrorButtons = (props: MirrorButtonsProps) => (
           <SubscribeButton
             key={`GitCDN`}
             name={props.name}
-            viewUrl={viewUrl}
             text={`Subscribe (GitCDN)`}
           />
         ))

--- a/web/src/components/SubscribeButtons.tsx
+++ b/web/src/components/SubscribeButtons.tsx
@@ -24,6 +24,7 @@ export const SubscribeButtons = (props: Props) =>
 interface MirrorButtonsProps {
   name: string;
   viewUrlMirrors: string[];
+  viewUrl: string;
 }
 
 const MirrorButtons = (props: MirrorButtonsProps) => (

--- a/web/src/components/SubscribeButtons.tsx
+++ b/web/src/components/SubscribeButtons.tsx
@@ -46,7 +46,7 @@ const MirrorButtons = (props: MirrorButtonsProps) => (
             viewUrl={props.viewUrl}
             text={`Subscribe (GitCDN)`}
           />
-        ))
+        }))
       : null}
   </>
 );


### PR DESCRIPTION
Considering that *Energized Protection* recently became the first adblock repo in history to be deactivated for using too much resources (They got back online after ~4 days), and uBO's very recent move to prioritise CDNs, I figured I could do some outstandingly desperate attempt at an initial implementation of #598.

I give myself a total of 2% chance of me having done this correct, but still.