### PR TITLE
 Changed mkb2091's lists to github pages

### DIFF
--- a/services/Directory/FilterLists.Directory.Infrastructure.Migrations/Migrations/20210219184255_2240.Designer.cs
+++ b/services/Directory/FilterLists.Directory.Infrastructure.Migrations/Migrations/20210219184255_2240.Designer.cs
@@ -3,15 +3,17 @@ using System;
 using FilterLists.Directory.Infrastructure.Persistence.Queries.Context;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
 namespace FilterLists.Directory.Infrastructure.Migrations.Migrations
 {
     [DbContext(typeof(QueryDbContext))]
-    partial class QueryDbContextModelSnapshot : ModelSnapshot
+    [Migration("20210219184255_2240")]
+    partial class _2240
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/services/Directory/FilterLists.Directory.Infrastructure.Migrations/Migrations/20210219184255_2240.cs
+++ b/services/Directory/FilterLists.Directory.Infrastructure.Migrations/Migrations/20210219184255_2240.cs
@@ -1,0 +1,97 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace FilterLists.Directory.Infrastructure.Migrations.Migrations
+{
+    public partial class _2240 : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.UpdateData(
+                table: "FilterListViewUrls",
+                keyColumn: "Id",
+                keyValue: 1936,
+                column: "Url",
+                value: "https://mkb2091.github.io/blockconvert/output/adblock.txt");
+
+            migrationBuilder.UpdateData(
+                table: "FilterListViewUrls",
+                keyColumn: "Id",
+                keyValue: 1937,
+                column: "Url",
+                value: "https://mkb2091.github.io/blockconvert/output/hosts.txt");
+
+            migrationBuilder.UpdateData(
+                table: "FilterListViewUrls",
+                keyColumn: "Id",
+                keyValue: 1938,
+                column: "Url",
+                value: "https://mkb2091.github.io/blockconvert/output/domains.txt");
+
+            migrationBuilder.UpdateData(
+                table: "FilterListViewUrls",
+                keyColumn: "Id",
+                keyValue: 1939,
+                column: "Url",
+                value: "https://mkb2091.github.io/blockconvert/output/ip_blocklist.txt");
+
+            migrationBuilder.UpdateData(
+                table: "FilterListViewUrls",
+                keyColumn: "Id",
+                keyValue: 1940,
+                column: "Url",
+                value: "https://mkb2091.github.io/blockconvert/output/domains.rpz");
+
+            migrationBuilder.UpdateData(
+                table: "FilterListViewUrls",
+                keyColumn: "Id",
+                keyValue: 1941,
+                column: "Url",
+                value: "https://mkb2091.github.io/blockconvert/output/whitelist_domains.txt");
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.UpdateData(
+                table: "FilterListViewUrls",
+                keyColumn: "Id",
+                keyValue: 1936,
+                column: "Url",
+                value: "https://raw.githubusercontent.com/mkb2091/blockconvert/master/output/adblock.txt");
+
+            migrationBuilder.UpdateData(
+                table: "FilterListViewUrls",
+                keyColumn: "Id",
+                keyValue: 1937,
+                column: "Url",
+                value: "https://raw.githubusercontent.com/mkb2091/blockconvert/master/output/hosts.txt");
+
+            migrationBuilder.UpdateData(
+                table: "FilterListViewUrls",
+                keyColumn: "Id",
+                keyValue: 1938,
+                column: "Url",
+                value: "https://raw.githubusercontent.com/mkb2091/blockconvert/master/output/domains.txt");
+
+            migrationBuilder.UpdateData(
+                table: "FilterListViewUrls",
+                keyColumn: "Id",
+                keyValue: 1939,
+                column: "Url",
+                value: "https://raw.githubusercontent.com/mkb2091/blockconvert/master/output/ip_blocklist.txt");
+
+            migrationBuilder.UpdateData(
+                table: "FilterListViewUrls",
+                keyColumn: "Id",
+                keyValue: 1940,
+                column: "Url",
+                value: "https://raw.githubusercontent.com/mkb2091/blockconvert/master/output/domains.rpz");
+
+            migrationBuilder.UpdateData(
+                table: "FilterListViewUrls",
+                keyColumn: "Id",
+                keyValue: 1941,
+                column: "Url",
+                value: "https://raw.githubusercontent.com/mkb2091/blockconvert/master/output/whitelist_domains.txt");
+        }
+    }
+}

--- a/services/Directory/data/FilterListViewUrl.json
+++ b/services/Directory/data/FilterListViewUrl.json
@@ -11577,37 +11577,37 @@
     "filterListId": 1868,
     "id": 1936,
     "primariness": 1,
-    "url": "https://raw.githubusercontent.com/mkb2091/blockconvert/master/output/adblock.txt"
+    "url": "https://mkb2091.github.io/blockconvert/output/adblock.txt"
   },
   {
     "filterListId": 1869,
     "id": 1937,
     "primariness": 1,
-    "url": "https://raw.githubusercontent.com/mkb2091/blockconvert/master/output/hosts.txt"
+    "url": "https://mkb2091.github.io/blockconvert/output/hosts.txt"
   },
   {
     "filterListId": 1870,
     "id": 1938,
     "primariness": 1,
-    "url": "https://raw.githubusercontent.com/mkb2091/blockconvert/master/output/domains.txt"
+    "url": "https://mkb2091.github.io/blockconvert/output/domains.txt"
   },
   {
     "filterListId": 1871,
     "id": 1939,
     "primariness": 1,
-    "url": "https://raw.githubusercontent.com/mkb2091/blockconvert/master/output/ip_blocklist.txt"
+    "url": "https://mkb2091.github.io/blockconvert/output/ip_blocklist.txt"
   },
   {
     "filterListId": 1872,
     "id": 1940,
     "primariness": 1,
-    "url": "https://raw.githubusercontent.com/mkb2091/blockconvert/master/output/domains.rpz"
+    "url": "https://mkb2091.github.io/blockconvert/output/domains.rpz"
   },
   {
     "filterListId": 1873,
     "id": 1941,
     "primariness": 1,
-    "url": "https://raw.githubusercontent.com/mkb2091/blockconvert/master/output/whitelist_domains.txt"
+    "url": "https://mkb2091.github.io/blockconvert/output/whitelist_domains.txt"
   },
   {
     "filterListId": 1876,


### PR DESCRIPTION
I'm under the impression that github pages mean software like Pi Hole doesn't have to redownload files when they haven't changed, so I've changed the url to use github pages