### PR TITLE
Remove 280blocker and its related filters that are / going to be obsolete

### DIFF
--- a/services/Directory/FilterLists.Directory.Infrastructure.Migrations/Migrations/20210902115704_2534.Designer.cs
+++ b/services/Directory/FilterLists.Directory.Infrastructure.Migrations/Migrations/20210902115704_2534.Designer.cs
@@ -3,15 +3,17 @@ using System;
 using FilterLists.Directory.Infrastructure.Persistence.Queries.Context;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
 namespace FilterLists.Directory.Infrastructure.Migrations.Migrations
 {
     [DbContext(typeof(QueryDbContext))]
-    partial class QueryDbContextModelSnapshot : ModelSnapshot
+    [Migration("20210902115704_2534")]
+    partial class _2534
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/services/Directory/FilterLists.Directory.Infrastructure.Migrations/Migrations/20210902115704_2534.cs
+++ b/services/Directory/FilterLists.Directory.Infrastructure.Migrations/Migrations/20210902115704_2534.cs
@@ -1,0 +1,427 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace FilterLists.Directory.Infrastructure.Migrations.Migrations
+{
+    public partial class _2534 : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DeleteData(
+                table: "FilterListLanguages",
+                keyColumns: new[] { "FilterListId", "Iso6391" },
+                keyValues: new object[] { 1, "ja" });
+
+            migrationBuilder.DeleteData(
+                table: "FilterListLanguages",
+                keyColumns: new[] { "FilterListId", "Iso6391" },
+                keyValues: new object[] { 1483, "ja" });
+
+            migrationBuilder.DeleteData(
+                table: "FilterListLanguages",
+                keyColumns: new[] { "FilterListId", "Iso6391" },
+                keyValues: new object[] { 1857, "ja" });
+
+            migrationBuilder.DeleteData(
+                table: "FilterListLanguages",
+                keyColumns: new[] { "FilterListId", "Iso6391" },
+                keyValues: new object[] { 1858, "ja" });
+
+            migrationBuilder.DeleteData(
+                table: "FilterListLanguages",
+                keyColumns: new[] { "FilterListId", "Iso6391" },
+                keyValues: new object[] { 1859, "ja" });
+
+            migrationBuilder.DeleteData(
+                table: "FilterListLanguages",
+                keyColumns: new[] { "FilterListId", "Iso6391" },
+                keyValues: new object[] { 1860, "ja" });
+
+            migrationBuilder.DeleteData(
+                table: "FilterListLanguages",
+                keyColumns: new[] { "FilterListId", "Iso6391" },
+                keyValues: new object[] { 1861, "ja" });
+
+            migrationBuilder.DeleteData(
+                table: "FilterListLanguages",
+                keyColumns: new[] { "FilterListId", "Iso6391" },
+                keyValues: new object[] { 1862, "ja" });
+
+            migrationBuilder.DeleteData(
+                table: "FilterListLanguages",
+                keyColumns: new[] { "FilterListId", "Iso6391" },
+                keyValues: new object[] { 1863, "ja" });
+
+            migrationBuilder.DeleteData(
+                table: "FilterListLanguages",
+                keyColumns: new[] { "FilterListId", "Iso6391" },
+                keyValues: new object[] { 2095, "ja" });
+
+            migrationBuilder.DeleteData(
+                table: "FilterListLanguages",
+                keyColumns: new[] { "FilterListId", "Iso6391" },
+                keyValues: new object[] { 2282, "ja" });
+
+            migrationBuilder.DeleteData(
+                table: "FilterListMaintainers",
+                keyColumns: new[] { "FilterListId", "MaintainerId" },
+                keyValues: new object[] { 1, 2 });
+
+            migrationBuilder.DeleteData(
+                table: "FilterListMaintainers",
+                keyColumns: new[] { "FilterListId", "MaintainerId" },
+                keyValues: new object[] { 1483, 2 });
+
+            migrationBuilder.DeleteData(
+                table: "FilterListSyntaxes",
+                keyColumns: new[] { "FilterListId", "SyntaxId" },
+                keyValues: new object[] { 1, 3 });
+
+            migrationBuilder.DeleteData(
+                table: "FilterListSyntaxes",
+                keyColumns: new[] { "FilterListId", "SyntaxId" },
+                keyValues: new object[] { 1483, 2 });
+
+            migrationBuilder.DeleteData(
+                table: "FilterListSyntaxes",
+                keyColumns: new[] { "FilterListId", "SyntaxId" },
+                keyValues: new object[] { 1857, 3 });
+
+            migrationBuilder.DeleteData(
+                table: "FilterListSyntaxes",
+                keyColumns: new[] { "FilterListId", "SyntaxId" },
+                keyValues: new object[] { 1858, 47 });
+
+            migrationBuilder.DeleteData(
+                table: "FilterListSyntaxes",
+                keyColumns: new[] { "FilterListId", "SyntaxId" },
+                keyValues: new object[] { 1859, 3 });
+
+            migrationBuilder.DeleteData(
+                table: "FilterListSyntaxes",
+                keyColumns: new[] { "FilterListId", "SyntaxId" },
+                keyValues: new object[] { 1860, 6 });
+
+            migrationBuilder.DeleteData(
+                table: "FilterListSyntaxes",
+                keyColumns: new[] { "FilterListId", "SyntaxId" },
+                keyValues: new object[] { 1861, 3 });
+
+            migrationBuilder.DeleteData(
+                table: "FilterListSyntaxes",
+                keyColumns: new[] { "FilterListId", "SyntaxId" },
+                keyValues: new object[] { 1862, 3 });
+
+            migrationBuilder.DeleteData(
+                table: "FilterListSyntaxes",
+                keyColumns: new[] { "FilterListId", "SyntaxId" },
+                keyValues: new object[] { 1863, 3 });
+
+            migrationBuilder.DeleteData(
+                table: "FilterListSyntaxes",
+                keyColumns: new[] { "FilterListId", "SyntaxId" },
+                keyValues: new object[] { 2095, 4 });
+
+            migrationBuilder.DeleteData(
+                table: "FilterListSyntaxes",
+                keyColumns: new[] { "FilterListId", "SyntaxId" },
+                keyValues: new object[] { 2282, 47 });
+
+            migrationBuilder.DeleteData(
+                table: "FilterListTags",
+                keyColumns: new[] { "FilterListId", "TagId" },
+                keyValues: new object[] { 1, 2 });
+
+            migrationBuilder.DeleteData(
+                table: "FilterListTags",
+                keyColumns: new[] { "FilterListId", "TagId" },
+                keyValues: new object[] { 1, 3 });
+
+            migrationBuilder.DeleteData(
+                table: "FilterListTags",
+                keyColumns: new[] { "FilterListId", "TagId" },
+                keyValues: new object[] { 1483, 3 });
+
+            migrationBuilder.DeleteData(
+                table: "FilterListTags",
+                keyColumns: new[] { "FilterListId", "TagId" },
+                keyValues: new object[] { 1483, 4 });
+
+            migrationBuilder.DeleteData(
+                table: "FilterListTags",
+                keyColumns: new[] { "FilterListId", "TagId" },
+                keyValues: new object[] { 1483, 10 });
+
+            migrationBuilder.DeleteData(
+                table: "FilterListTags",
+                keyColumns: new[] { "FilterListId", "TagId" },
+                keyValues: new object[] { 1857, 2 });
+
+            migrationBuilder.DeleteData(
+                table: "FilterListTags",
+                keyColumns: new[] { "FilterListId", "TagId" },
+                keyValues: new object[] { 1858, 3 });
+
+            migrationBuilder.DeleteData(
+                table: "FilterListTags",
+                keyColumns: new[] { "FilterListId", "TagId" },
+                keyValues: new object[] { 1859, 9 });
+
+            migrationBuilder.DeleteData(
+                table: "FilterListTags",
+                keyColumns: new[] { "FilterListId", "TagId" },
+                keyValues: new object[] { 1860, 10 });
+
+            migrationBuilder.DeleteData(
+                table: "FilterListTags",
+                keyColumns: new[] { "FilterListId", "TagId" },
+                keyValues: new object[] { 1861, 10 });
+
+            migrationBuilder.DeleteData(
+                table: "FilterListTags",
+                keyColumns: new[] { "FilterListId", "TagId" },
+                keyValues: new object[] { 1862, 2 });
+
+            migrationBuilder.DeleteData(
+                table: "FilterListTags",
+                keyColumns: new[] { "FilterListId", "TagId" },
+                keyValues: new object[] { 1863, 2 });
+
+            migrationBuilder.DeleteData(
+                table: "FilterListTags",
+                keyColumns: new[] { "FilterListId", "TagId" },
+                keyValues: new object[] { 2095, 7 });
+
+            migrationBuilder.DeleteData(
+                table: "FilterListTags",
+                keyColumns: new[] { "FilterListId", "TagId" },
+                keyValues: new object[] { 2282, 3 });
+
+            migrationBuilder.DeleteData(
+                table: "FilterListTags",
+                keyColumns: new[] { "FilterListId", "TagId" },
+                keyValues: new object[] { 2282, 4 });
+
+            migrationBuilder.DeleteData(
+                table: "FilterListTags",
+                keyColumns: new[] { "FilterListId", "TagId" },
+                keyValues: new object[] { 2282, 10 });
+
+            migrationBuilder.DeleteData(
+                table: "FilterListViewUrls",
+                keyColumn: "Id",
+                keyValue: 1);
+
+            migrationBuilder.DeleteData(
+                table: "FilterListViewUrls",
+                keyColumn: "Id",
+                keyValue: 1491);
+
+            migrationBuilder.DeleteData(
+                table: "FilterListViewUrls",
+                keyColumn: "Id",
+                keyValue: 1925);
+
+            migrationBuilder.DeleteData(
+                table: "FilterListViewUrls",
+                keyColumn: "Id",
+                keyValue: 1926);
+
+            migrationBuilder.DeleteData(
+                table: "FilterListViewUrls",
+                keyColumn: "Id",
+                keyValue: 1927);
+
+            migrationBuilder.DeleteData(
+                table: "FilterListViewUrls",
+                keyColumn: "Id",
+                keyValue: 1928);
+
+            migrationBuilder.DeleteData(
+                table: "FilterListViewUrls",
+                keyColumn: "Id",
+                keyValue: 1929);
+
+            migrationBuilder.DeleteData(
+                table: "FilterListViewUrls",
+                keyColumn: "Id",
+                keyValue: 1930);
+
+            migrationBuilder.DeleteData(
+                table: "FilterListViewUrls",
+                keyColumn: "Id",
+                keyValue: 1931);
+
+            migrationBuilder.DeleteData(
+                table: "FilterListViewUrls",
+                keyColumn: "Id",
+                keyValue: 2202);
+
+            migrationBuilder.DeleteData(
+                table: "FilterListViewUrls",
+                keyColumn: "Id",
+                keyValue: 2425);
+
+            migrationBuilder.DeleteData(
+                table: "FilterLists",
+                keyColumn: "Id",
+                keyValue: 1);
+
+            migrationBuilder.DeleteData(
+                table: "FilterLists",
+                keyColumn: "Id",
+                keyValue: 1483);
+
+            migrationBuilder.DeleteData(
+                table: "FilterLists",
+                keyColumn: "Id",
+                keyValue: 1857);
+
+            migrationBuilder.DeleteData(
+                table: "FilterLists",
+                keyColumn: "Id",
+                keyValue: 1858);
+
+            migrationBuilder.DeleteData(
+                table: "FilterLists",
+                keyColumn: "Id",
+                keyValue: 1859);
+
+            migrationBuilder.DeleteData(
+                table: "FilterLists",
+                keyColumn: "Id",
+                keyValue: 1860);
+
+            migrationBuilder.DeleteData(
+                table: "FilterLists",
+                keyColumn: "Id",
+                keyValue: 1861);
+
+            migrationBuilder.DeleteData(
+                table: "FilterLists",
+                keyColumn: "Id",
+                keyValue: 1862);
+
+            migrationBuilder.DeleteData(
+                table: "FilterLists",
+                keyColumn: "Id",
+                keyValue: 1863);
+
+            migrationBuilder.DeleteData(
+                table: "FilterLists",
+                keyColumn: "Id",
+                keyValue: 2095);
+
+            migrationBuilder.DeleteData(
+                table: "FilterLists",
+                keyColumn: "Id",
+                keyValue: 2282);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.InsertData(
+                table: "FilterLists",
+                columns: new[] { "Id", "ChatUrl", "Description", "DonateUrl", "EmailAddress", "ForumUrl", "HomeUrl", "IssuesUrl", "LicenseId", "Name", "OnionUrl", "PolicyUrl", "SubmissionUrl" },
+                values: new object[,]
+                {
+                    { 1, null, "A filter list that blocks mobile advertisements and trackers on Japanese properties", null, null, null, "https://280blocker.net/", null, 1, "280blocker for japanese mobile site", null, null, "https://docs.google.com/forms/d/e/1FAIpQLScNeZhFrFZt9GhIVGdThGz7oyepcNRKuOi5PJDnsC-awxTeOQ/viewform" },
+                    { 1483, null, "A filter list that blocks mobile advertisements and trackers on Japanese properties", null, null, null, "https://280blocker.net/", null, 1, "280blocker adblock domain lists", null, null, "https://docs.google.com/forms/d/e/1FAIpQLScNeZhFrFZt9GhIVGdThGz7oyepcNRKuOi5PJDnsC-awxTeOQ/viewform" },
+                    { 1857, null, "This is a filter to complement 280blocker by finding advertisements that are not blocked by 280blocker.", null, null, null, "https://github.com/nanj-adguard2/nanj-kakuchou-filter", null, 20, "Nanj Kakuchou Filter - Supplement Rules", null, null, null },
+                    { 1858, null, "DNS rule filters to strengthen ad blocking.", null, null, null, "https://github.com/nanj-adguard2/nanj-kakuchou-filter", null, 20, "Nanj Kakuchou Filter - DNS Rules", null, null, null },
+                    { 1859, null, "This is a filter that eradicates what 280blocker will not support in the future.", null, null, null, "https://github.com/nanj-adguard2/nanj-kakuchou-filter", null, 20, "Nanj Kakuchou Filter - Paranoid Rules", null, null, null },
+                    { 1860, null, "This is a filter to fix bugs in AdGuard for Android when using Japanese websites / Japanese apps / 280blocker.", null, null, null, "https://github.com/nanj-adguard2/nanj-kaishuu-filter", null, 20, "Nanj Kaishuu Filter", null, null, null },
+                    { 1861, null, "This is a filter to fix bugs in AdGuard for Android when using Japanese websites / Japanese apps / 280blocker.", null, null, null, "https://github.com/nanj-adguard2/nanj-kaishuu-filter", null, 20, "Nanj Kaishuu DNS Filter", null, null, null },
+                    { 1862, null, "This is a filter to fix bugs in AdGuard for Android when using Japanese websites / Japanese apps / 280blocker.", null, null, null, "https://github.com/nanj-adguard2/nanj-kaishuu-filter", null, 1, "280blocker + Nanj Kakuchou", null, null, null },
+                    { 1863, null, "This is a filter to fix bugs in AdGuard for Android when using Japanese websites / Japanese apps / 280blocker.", null, null, null, "https://github.com/nanj-adguard2/nanj-kaishuu-filter", null, 1, "280blocker + Nanj Kakuchou - Supplement Rules", null, null, null },
+                    { 2095, null, "Enhance anti-scam capability of 280blocker adblock filter by utilizing advanced capability of AdGuard/uBlock Origin.", null, null, null, "https://github.com/Yuki2718/adblock", "https://github.com/Yuki2718/adblock/issues", 28, "Anti-scam enhancer for 280blocker adblock filter", null, null, null },
+                    { 2282, null, "A filter list that blocks mobile advertisements and trackers on Japanese properties", null, null, null, "https://280blocker.net/", null, 1, "280blocker adblock domain lists (AdGuard)", null, null, "https://docs.google.com/forms/d/e/1FAIpQLScNeZhFrFZt9GhIVGdThGz7oyepcNRKuOi5PJDnsC-awxTeOQ/viewform" }
+                });
+
+            migrationBuilder.InsertData(
+                table: "FilterListLanguages",
+                columns: new[] { "FilterListId", "Iso6391" },
+                values: new object[,]
+                {
+                    { 1, "ja" },
+                    { 2282, "ja" },
+                    { 2095, "ja" },
+                    { 1863, "ja" },
+                    { 1862, "ja" },
+                    { 1861, "ja" },
+                    { 1859, "ja" },
+                    { 1858, "ja" },
+                    { 1857, "ja" },
+                    { 1860, "ja" },
+                    { 1483, "ja" }
+                });
+
+            migrationBuilder.InsertData(
+                table: "FilterListMaintainers",
+                columns: new[] { "FilterListId", "MaintainerId" },
+                values: new object[,]
+                {
+                    { 1, 2 },
+                    { 1483, 2 }
+                });
+
+            migrationBuilder.InsertData(
+                table: "FilterListSyntaxes",
+                columns: new[] { "FilterListId", "SyntaxId" },
+                values: new object[,]
+                {
+                    { 1861, 3 },
+                    { 1860, 6 },
+                    { 1863, 3 },
+                    { 1, 3 },
+                    { 1859, 3 },
+                    { 1862, 3 },
+                    { 2095, 4 },
+                    { 1858, 47 },
+                    { 2282, 47 },
+                    { 1857, 3 },
+                    { 1483, 2 }
+                });
+
+            migrationBuilder.InsertData(
+                table: "FilterListTags",
+                columns: new[] { "FilterListId", "TagId" },
+                values: new object[,]
+                {
+                    { 1863, 2 },
+                    { 2282, 3 },
+                    { 2282, 4 },
+                    { 1, 2 },
+                    { 1862, 2 },
+                    { 2095, 7 },
+                    { 1, 3 },
+                    { 1483, 4 },
+                    { 1859, 9 },
+                    { 1483, 3 },
+                    { 1483, 10 },
+                    { 1857, 2 },
+                    { 1860, 10 },
+                    { 2282, 10 },
+                    { 1861, 10 },
+                    { 1858, 3 }
+                });
+
+            migrationBuilder.InsertData(
+                table: "FilterListViewUrls",
+                columns: new[] { "Id", "FilterListId", "Primariness", "Url" },
+                values: new object[,]
+                {
+                    { 1491, 1483, (short)1, "https://280blocker.net/files/280blocker_domain.txt" },
+                    { 1925, 1857, (short)1, "https://raw.githubusercontent.com/nanj-adguard2/nanj-kakuchou-filter/master/supplement-rules.txt" },
+                    { 2202, 2095, (short)1, "https://raw.githubusercontent.com/Yuki2718/adblock/master/japanese/280-patch.txt" },
+                    { 1929, 1861, (short)1, "https://raw.githubusercontent.com/nanj-adguard2/nanj-kaishuu-filter/master/nanj-kaishuu-dns-filter.txt" },
+                    { 1931, 1863, (short)1, "https://280blocker.net/files/280blocker_adblock_nanj_supp.txt" },
+                    { 1927, 1859, (short)1, "https://raw.githubusercontent.com/nanj-adguard2/nanj-kakuchou-filter/master/paranoid-rules.txt" },
+                    { 1930, 1862, (short)1, "https://280blocker.net/files/280blocker_adblock_nanj.txt" },
+                    { 1928, 1860, (short)1, "https://raw.githubusercontent.com/nanj-adguard2/nanj-kaishuu-filter/master/nanj-kaishuu-filter.txt" },
+                    { 1, 1, (short)1, "https://280blocker.net/files/280blocker_adblock.txt" },
+                    { 1926, 1858, (short)1, "https://raw.githubusercontent.com/nanj-adguard2/nanj-kakuchou-filter/master/DNS-rules.txt" },
+                    { 2425, 2282, (short)1, "https://280blocker.net/files/280blocker_domain_ag.txt" }
+                });
+        }
+    }
+}

--- a/services/Directory/data/FilterList.json
+++ b/services/Directory/data/FilterList.json
@@ -1,13 +1,5 @@
 [
   {
-    "description": "A filter list that blocks mobile advertisements and trackers on Japanese properties",
-    "homeUrl": "https://280blocker.net",
-    "id": 1,
-    "licenseId": 1,
-    "name": "280blocker for japanese mobile site",
-    "submissionUrl": "https://docs.google.com/forms/d/e/1FAIpQLScNeZhFrFZt9GhIVGdThGz7oyepcNRKuOi5PJDnsC-awxTeOQ/viewform"
-  },
-  {
     "description": "Mute is an AdBlock Plus filter for user comments. In the same way that AdBlock hides ads, AdBlock can use this filter to hide user-generated comments, allowing you to browse the Internet with less stupidity clawing at your eyeballs.",
     "homeUrl": "https://github.com/B-Con/mute",
     "id": 2,
@@ -9297,14 +9289,6 @@
     "name": "jawz101 MobileAdTrackers"
   },
   {
-    "description": "A filter list that blocks mobile advertisements and trackers on Japanese properties",
-    "homeUrl": "https://280blocker.net",
-    "id": 1483,
-    "licenseId": 1,
-    "name": "280blocker adblock domain lists",
-    "submissionUrl": "https://docs.google.com/forms/d/e/1FAIpQLScNeZhFrFZt9GhIVGdThGz7oyepcNRKuOi5PJDnsC-awxTeOQ/viewform"
-  },
-  {
     "homeUrl": "https://blocklist.site/",
     "id": 1484,
     "licenseId": 11,
@@ -12403,55 +12387,6 @@
     "name": "nocomments"
   },
   {
-    "description": "This is a filter to complement 280blocker by finding advertisements that are not blocked by 280blocker.",
-    "homeUrl": "https://github.com/nanj-adguard2/nanj-kakuchou-filter",
-    "id": 1857,
-    "licenseId": 20,
-    "name": "Nanj Kakuchou Filter - Supplement Rules"
-  },
-  {
-    "description": "DNS rule filters to strengthen ad blocking.",
-    "homeUrl": "https://github.com/nanj-adguard2/nanj-kakuchou-filter",
-    "id": 1858,
-    "licenseId": 20,
-    "name": "Nanj Kakuchou Filter - DNS Rules"
-  },
-  {
-    "description": "This is a filter that eradicates what 280blocker will not support in the future.",
-    "homeUrl": "https://github.com/nanj-adguard2/nanj-kakuchou-filter",
-    "id": 1859,
-    "licenseId": 20,
-    "name": "Nanj Kakuchou Filter - Paranoid Rules"
-  },
-  {
-    "description": "This is a filter to fix bugs in AdGuard for Android when using Japanese websites / Japanese apps / 280blocker.",
-    "homeUrl": "https://github.com/nanj-adguard2/nanj-kaishuu-filter",
-    "id": 1860,
-    "licenseId": 20,
-    "name": "Nanj Kaishuu Filter"
-  },
-  {
-    "description": "This is a filter to fix bugs in AdGuard for Android when using Japanese websites / Japanese apps / 280blocker.",
-    "homeUrl": "https://github.com/nanj-adguard2/nanj-kaishuu-filter",
-    "id": 1861,
-    "licenseId": 20,
-    "name": "Nanj Kaishuu DNS Filter"
-  },
-  {
-    "description": "This is a filter to fix bugs in AdGuard for Android when using Japanese websites / Japanese apps / 280blocker.",
-    "homeUrl": "https://github.com/nanj-adguard2/nanj-kaishuu-filter",
-    "id": 1862,
-    "licenseId": 1,
-    "name": "280blocker + Nanj Kakuchou"
-  },
-  {
-    "description": "This is a filter to fix bugs in AdGuard for Android when using Japanese websites / Japanese apps / 280blocker.",
-    "homeUrl": "https://github.com/nanj-adguard2/nanj-kaishuu-filter",
-    "id": 1863,
-    "licenseId": 1,
-    "name": "280blocker + Nanj Kakuchou - Supplement Rules"
-  },
-  {
     "description": "This is a quick list of Ad-blocking filters for Sri Lankan web sites. Use this to complement Easylist filters.",
     "homeUrl": "https://github.com/Ayesh/Adblock-Sinhala/",
     "id": 1864,
@@ -14111,14 +14046,6 @@
     "name": "Yuki's uBlock Japanese filters - Annoyances"
   },
   {
-    "description": "Enhance anti-scam capability of 280blocker adblock filter by utilizing advanced capability of AdGuard/uBlock Origin.",
-    "homeUrl": "https://github.com/Yuki2718/adblock",
-    "id": 2095,
-    "issuesUrl": "https://github.com/Yuki2718/adblock/issues",
-    "licenseId": 28,
-    "name": "Anti-scam enhancer for 280blocker adblock filter"
-  },
-  {
     "description": "Removes blogroll (feed-style mutual links) on Japanese sites. Included in Yuki's uBlock Japanese filters - Annoyances",
     "homeUrl": "https://github.com/Yuki2718/adblock",
     "id": 2096,
@@ -15527,14 +15454,6 @@
     "id": 2281,
     "licenseId": 35,
     "name": "1Hosts Pro (Domains with wildcards)"
-  },
-  {
-    "description": "A filter list that blocks mobile advertisements and trackers on Japanese properties",
-    "homeUrl": "https://280blocker.net",
-    "id": 2282,
-    "licenseId": 1,
-    "name": "280blocker adblock domain lists (AdGuard)",
-    "submissionUrl": "https://docs.google.com/forms/d/e/1FAIpQLScNeZhFrFZt9GhIVGdThGz7oyepcNRKuOi5PJDnsC-awxTeOQ/viewform"
   },
   {
     "description": "Goodbye Ads is designed for Unix-like systems (such as Android), gets a list of domains that serve ads, tracking scripts and malware from multiple reputable sources and creates a hosts file that prevents your system from connecting to them.",

--- a/services/Directory/data/FilterListLanguage.json
+++ b/services/Directory/data/FilterListLanguage.json
@@ -1,9 +1,5 @@
 [
   {
-    "filterListId": 1,
-    "iso6391": "ja"
-  },
-  {
     "filterListId": 6,
     "iso6391": "ja"
   },
@@ -2280,10 +2276,6 @@
     "iso6391": "zh"
   },
   {
-    "filterListId": 1483,
-    "iso6391": "ja"
-  },
-  {
     "filterListId": 1528,
     "iso6391": "az"
   },
@@ -2736,34 +2728,6 @@
     "iso6391": "th"
   },
   {
-    "filterListId": 1857,
-    "iso6391": "ja"
-  },
-  {
-    "filterListId": 1858,
-    "iso6391": "ja"
-  },
-  {
-    "filterListId": 1859,
-    "iso6391": "ja"
-  },
-  {
-    "filterListId": 1860,
-    "iso6391": "ja"
-  },
-  {
-    "filterListId": 1861,
-    "iso6391": "ja"
-  },
-  {
-    "filterListId": 1862,
-    "iso6391": "ja"
-  },
-  {
-    "filterListId": 1863,
-    "iso6391": "ja"
-  },
-  {
     "filterListId": 1864,
     "iso6391": "si"
   },
@@ -2969,10 +2933,6 @@
   },
   {
     "filterListId": 2094,
-    "iso6391": "ja"
-  },
-  {
-    "filterListId": 2095,
     "iso6391": "ja"
   },
   {
@@ -3534,10 +3494,6 @@
   {
     "filterListId": 2278,
     "iso6391": "de"
-  },
-  {
-    "filterListId": 2282,
-    "iso6391": "ja"
   },
   {
     "filterListId": 2286,

--- a/services/Directory/data/FilterListMaintainer.json
+++ b/services/Directory/data/FilterListMaintainer.json
@@ -1,9 +1,5 @@
 [
   {
-    "filterListId": 1,
-    "maintainerId": 2
-  },
-  {
     "filterListId": 2,
     "maintainerId": 3
   },
@@ -3882,10 +3878,6 @@
   {
     "filterListId": 1480,
     "maintainerId": 118
-  },
-  {
-    "filterListId": 1483,
-    "maintainerId": 2
   },
   {
     "filterListId": 1484,

--- a/services/Directory/data/FilterListSyntax.json
+++ b/services/Directory/data/FilterListSyntax.json
@@ -1,9 +1,5 @@
 [
   {
-    "filterListId": 1,
-    "syntaxId": 3
-  },
-  {
     "filterListId": 2,
     "syntaxId": 3
   },
@@ -4784,10 +4780,6 @@
     "syntaxId": 1
   },
   {
-    "filterListId": 1483,
-    "syntaxId": 2
-  },
-  {
     "filterListId": 1484,
     "syntaxId": 2
   },
@@ -6188,34 +6180,6 @@
     "syntaxId": 3
   },
   {
-    "filterListId": 1857,
-    "syntaxId": 3
-  },
-  {
-    "filterListId": 1858,
-    "syntaxId": 47
-  },
-  {
-    "filterListId": 1859,
-    "syntaxId": 3
-  },
-  {
-    "filterListId": 1860,
-    "syntaxId": 6
-  },
-  {
-    "filterListId": 1861,
-    "syntaxId": 3
-  },
-  {
-    "filterListId": 1862,
-    "syntaxId": 3
-  },
-  {
-    "filterListId": 1863,
-    "syntaxId": 3
-  },
-  {
     "filterListId": 1864,
     "syntaxId": 3
   },
@@ -7108,10 +7072,6 @@
     "syntaxId": 4
   },
   {
-    "filterListId": 2095,
-    "syntaxId": 4
-  },
-  {
     "filterListId": 2096,
     "syntaxId": 4
   },
@@ -7854,10 +7814,6 @@
   {
     "filterListId": 2281,
     "syntaxId": 16
-  },
-  {
-    "filterListId": 2282,
-    "syntaxId": 47
   },
   {
     "filterListId": 2283,

--- a/services/Directory/data/FilterListTag.json
+++ b/services/Directory/data/FilterListTag.json
@@ -1,13 +1,5 @@
 [
   {
-    "filterListId": 1,
-    "tagId": 2
-  },
-  {
-    "filterListId": 1,
-    "tagId": 3
-  },
-  {
     "filterListId": 2,
     "tagId": 4
   },
@@ -6176,18 +6168,6 @@
     "tagId": 4
   },
   {
-    "filterListId": 1483,
-    "tagId": 3
-  },
-  {
-    "filterListId": 1483,
-    "tagId": 4
-  },
-  {
-    "filterListId": 1483,
-    "tagId": 10
-  },
-  {
     "filterListId": 1484,
     "tagId": 24
   },
@@ -9096,34 +9076,6 @@
     "tagId": 4
   },
   {
-    "filterListId": 1857,
-    "tagId": 2
-  },
-  {
-    "filterListId": 1858,
-    "tagId": 3
-  },
-  {
-    "filterListId": 1859,
-    "tagId": 9
-  },
-  {
-    "filterListId": 1860,
-    "tagId": 10
-  },
-  {
-    "filterListId": 1861,
-    "tagId": 10
-  },
-  {
-    "filterListId": 1862,
-    "tagId": 2
-  },
-  {
-    "filterListId": 1863,
-    "tagId": 2
-  },
-  {
     "filterListId": 1864,
     "tagId": 2
   },
@@ -10536,10 +10488,6 @@
     "tagId": 9
   },
   {
-    "filterListId": 2095,
-    "tagId": 7
-  },
-  {
     "filterListId": 2096,
     "tagId": 9
   },
@@ -11382,18 +11330,6 @@
   {
     "filterListId": 2281,
     "tagId": 6
-  },
-  {
-    "filterListId": 2282,
-    "tagId": 3
-  },
-  {
-    "filterListId": 2282,
-    "tagId": 4
-  },
-  {
-    "filterListId": 2282,
-    "tagId": 10
   },
   {
     "filterListId": 2283,

--- a/services/Directory/data/FilterListViewUrl.json
+++ b/services/Directory/data/FilterListViewUrl.json
@@ -1,11 +1,5 @@
 [
   {
-    "filterListId": 1,
-    "id": 1,
-    "primariness": 1,
-    "url": "https://280blocker.net/files/280blocker_adblock.txt"
-  },
-  {
     "filterListId": 2,
     "id": 2,
     "primariness": 1,
@@ -8850,12 +8844,6 @@
     "url": "https://raw.githubusercontent.com/jawz101/MobileAdTrackers/master/hosts"
   },
   {
-    "filterListId": 1483,
-    "id": 1491,
-    "primariness": 1,
-    "url": "https://280blocker.net/files/280blocker_domain.txt"
-  },
-  {
     "filterListId": 1484,
     "id": 1492,
     "primariness": 1,
@@ -11454,48 +11442,6 @@
     "url": "https://raw.githubusercontent.com/lutoma/nocomments/master/abp.txt"
   },
   {
-    "filterListId": 1857,
-    "id": 1925,
-    "primariness": 1,
-    "url": "https://raw.githubusercontent.com/nanj-adguard2/nanj-kakuchou-filter/master/supplement-rules.txt"
-  },
-  {
-    "filterListId": 1858,
-    "id": 1926,
-    "primariness": 1,
-    "url": "https://raw.githubusercontent.com/nanj-adguard2/nanj-kakuchou-filter/master/DNS-rules.txt"
-  },
-  {
-    "filterListId": 1859,
-    "id": 1927,
-    "primariness": 1,
-    "url": "https://raw.githubusercontent.com/nanj-adguard2/nanj-kakuchou-filter/master/paranoid-rules.txt"
-  },
-  {
-    "filterListId": 1860,
-    "id": 1928,
-    "primariness": 1,
-    "url": "https://raw.githubusercontent.com/nanj-adguard2/nanj-kaishuu-filter/master/nanj-kaishuu-filter.txt"
-  },
-  {
-    "filterListId": 1861,
-    "id": 1929,
-    "primariness": 1,
-    "url": "https://raw.githubusercontent.com/nanj-adguard2/nanj-kaishuu-filter/master/nanj-kaishuu-dns-filter.txt"
-  },
-  {
-    "filterListId": 1862,
-    "id": 1930,
-    "primariness": 1,
-    "url": "https://280blocker.net/files/280blocker_adblock_nanj.txt"
-  },
-  {
-    "filterListId": 1863,
-    "id": 1931,
-    "primariness": 1,
-    "url": "https://280blocker.net/files/280blocker_adblock_nanj_supp.txt"
-  },
-  {
     "filterListId": 1864,
     "id": 1932,
     "primariness": 1,
@@ -13098,12 +13044,6 @@
     "url": "https://raw.githubusercontent.com/Yuki2718/adblock/master/japanese/jp-annoyances.txt"
   },
   {
-    "filterListId": 2095,
-    "id": 2202,
-    "primariness": 1,
-    "url": "https://raw.githubusercontent.com/Yuki2718/adblock/master/japanese/280-patch.txt"
-  },
-  {
     "filterListId": 2099,
     "id": 2203,
     "primariness": 1,
@@ -14356,12 +14296,6 @@
     "id": 2424,
     "primariness": 2,
     "url": "https://raw.githubusercontent.com/badmojr/1Hosts/master/Pro/wildcards.txt"
-  },
-  {
-    "filterListId": 2282,
-    "id": 2425,
-    "primariness": 1,
-    "url": "https://280blocker.net/files/280blocker_domain_ag.txt"
   },
   {
     "filterListId": 2283,


### PR DESCRIPTION
All 280blocker's filters are going to be private in mid Sept as bought by Tobila: `https://280blocker.net/blog/20210831/3043/`. Also nanj-kaishu-filter and nanj-kakuchou-filter are dead on GH (they are still available on `https://wikiwiki.jp/nanj-adguard/%E3%81%AA%E3%82%93J%E6%94%B9%E4%BF%AE%E3%83%95%E3%82%A3%E3%83%AB%E3%82%BF%E3%83%BC`, `https://wikiwiki.jp/nanj-adguard/%E3%81%AA%E3%82%93J%E6%8B%A1%E5%BC%B5%E3%83%95%E3%82%A3%E3%83%AB%E3%82%BF%E3%83%BC` but almost no more maintained, it's questionable if they're worth adding.) I'm going to remove Anti-scam enhancer for 280blocker adblock filter once I confirmed 280blocker adblock filter is inaccessible.

P.s. After this PR is merged I'll open a new PR to add my new list, all to avoid conflict.