### PR TITLE
feat(dir): ✨ include primaryViewUrl in /lists endpoint

### DIFF
--- a/services/Directory/FilterLists.Directory.Api.Contracts/Models/ListVm.cs
+++ b/services/Directory/FilterLists.Directory.Api.Contracts/Models/ListVm.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 
 namespace FilterLists.Directory.Api.Contracts.Models
 {
@@ -11,6 +12,7 @@ namespace FilterLists.Directory.Api.Contracts.Models
         public IEnumerable<int>? SyntaxIds { get; init; }
         public IEnumerable<string>? Iso6391s { get; init; }
         public IEnumerable<int>? TagIds { get; init; }
+        public Uri? PrimaryViewUrl { get; init; }
         public IEnumerable<int>? MaintainerIds { get; init; }
     }
 }

--- a/services/Directory/FilterLists.Directory.Application/Queries/GetLists.cs
+++ b/services/Directory/FilterLists.Directory.Application/Queries/GetLists.cs
@@ -54,6 +54,10 @@ namespace FilterLists.Directory.Application.Queries
                     .ForMember(fl => fl.TagIds,
                         o => o.MapFrom(fl =>
                             fl.FilterListTags.Select(flt => flt.TagId).OrderBy(tid => tid).AsEnumerable()))
+                    .ForMember(fl => fl.PrimaryViewUrl,
+                        o => o.MapFrom(fl =>
+                            fl.ViewUrls.OrderBy(u => u.SegmentNumber).ThenBy(u => u.Primariness).Select(u => u.Url)
+                                .FirstOrDefault()))
                     .ForMember(fl => fl.MaintainerIds,
                         o => o.MapFrom(fl =>
                             fl.FilterListMaintainers.Select(flm => flm.MaintainerId).OrderBy(mid => mid)


### PR DESCRIPTION
resolves #2516 

just adding the "primary" `viewUrl` to this endpoint since it already returns a very large response. if the backup urls or urls for other "segments" are needed, then the list details endpoint for a specific list can still be used.

![image](https://user-images.githubusercontent.com/6483057/139949159-84eb69b3-053b-4f09-8c53-6b66d2e5b195.png)
