### PR TITLE
My Privacy DNS Porn Records Blacklist

### DIFF
--- a/services/Directory/data/FilterList.json
+++ b/services/Directory/data/FilterList.json
@@ -17246,5 +17246,20 @@
     "issuesUrl": "https://github.com/FiltersHeroes/PCCassets/issues",
     "licenseId": 4,
     "name": "European Cookie Database"
+  },
+  {
+    "description": "Porn Records Blacklisting. Porn Records from My Privacy DNS is among the best maintained projects and one of them with the lowest FP's as all records are veryfied by a human before committed to the lists. We do also have a Browser add-on for simple committing new domains",
+    "donateUrl": "https://ko-fi.com/X8X37FUGU",
+    "emailAddress": "incoming+my-privacy-dns-porn-records-2-dmptefj25u6tlslz82c3oolb9-issue@noreply.mypdns.org",
+    "chatUrl": "https://matrix.to/#/#porn-records:anontier.nl",
+    "homeUrl": "https://mypdns.org/my-privacy-dns/porn-records",
+    "viewUrlMirror1": "https://github.com/porn-records/Porn-Records",
+    "viewUrlMirror2": "https://gitlab.com/MypDNS/porn-records",
+    "id": 2566,
+    "issuesUrl": "https://mypdns.org/my-privacy-dns/porn-records/-/issues",
+    "licenseId": 13,
+    "name": "My Privacy DNS - Porn Records Blacklist",
+    "policyUrl": "https://mypdns.org/my-privacy-dns/porn-records/-/blob/master/README.md",
+    "submissionUrl": "https://mypdns.org/my-privacy-dns/porn-records/-/issues"
   }
 ]

--- a/services/Directory/data/FilterListLanguage.json
+++ b/services/Directory/data/FilterListLanguage.json
@@ -3730,5 +3730,9 @@
   {
     "filterListId": 2564,
     "languageId": 125
+  },
+  {
+    "filterListId": 2566,
+    "languageId": 37
   }
 ]

--- a/services/Directory/data/FilterListMaintainer.json
+++ b/services/Directory/data/FilterListMaintainer.json
@@ -5742,5 +5742,14 @@
   {
     "filterListId": 2565,
     "maintainerId": 34
+  },
+  {
+    "filterListId": 2566,
+    "maintainerId": [
+      "168",
+      "169",
+      "170",
+      "171"
+    ]
   }
 ]

--- a/services/Directory/data/FilterListTag.json
+++ b/services/Directory/data/FilterListTag.json
@@ -12606,5 +12606,9 @@
   {
     "filterListId": 2565,
     "tagId": 8
+  },
+  {
+    "filterListId": 2566,
+    "tagId": 11
   }
 ]

--- a/services/Directory/data/FilterListViewUrl.json
+++ b/services/Directory/data/FilterListViewUrl.json
@@ -15909,5 +15909,145 @@
     "id": 2813,
     "primariness": 3,
     "url": "https://cdn.statically.io/gh/JohnyP36/Personal-List/main/Personal%20List%20(uBo).txt"
+  },
+  {
+    "filterListId": 2566,
+    "id": 2814,
+    "primariness": 1,
+    "segmentNumber": 1,
+    "url": "https://mypdns.org/my-privacy-dns/porn-records/-/raw/master/submit_here/adult.mypdns.cloud/wildcard.list"
+  },
+  {
+    "filterListId": 2566,
+    "id": 2815,
+    "primariness": 2,
+    "segmentNumber": 1,
+    "url": "https://raw.githubusercontent.com/mypdns/porn-records/master/submit_here/adult.mypdns.cloud/wildcard.list"
+  },
+  {
+    "filterListId": 2566,
+    "id": 2816,
+    "primariness": 3,
+    "segmentNumber": 1,
+    "url": "https://raw.githubusercontent.com/porn-records/porn-records/master/submit_here/adult.mypdns.cloud/wildcard.list"
+  },
+  {
+    "filterListId": 2566,
+    "id": 2817,
+    "primariness": 4,
+    "segmentNumber": 1,
+    "url": "https://gitlab.com/MypDNS/porn-records/-/raw/master/submit_here/adult.mypdns.cloud/wildcard.list"
+  },
+  {
+    "filterListId": 2566,
+    "id": 2818,
+    "primariness": 1,
+    "segmentNumber": 2,
+    "url": "https://mypdns.org/my-privacy-dns/porn-records/-/raw/master/submit_here/adult.mypdns.cloud/tld.list"
+  },
+  {
+    "filterListId": 2566,
+    "id": 2819,
+    "primariness": 2,
+    "segmentNumber": 2,
+    "url": "https://raw.githubusercontent.com/mypdns/porn-records/master/submit_here/adult.mypdns.cloud/tld.list"
+  },
+  {
+    "filterListId": 2566,
+    "id": 2820,
+    "primariness": 3,
+    "segmentNumber": 2,
+    "url": "https://raw.githubusercontent.com/porn-records/porn-records/master/submit_here/adult.mypdns.cloud/tld.list"
+  },
+  {
+    "filterListId": 2566,
+    "id": 2821,
+    "primariness": 4,
+    "segmentNumber": 2,
+    "url": "https://gitlab.com/MypDNS/porn-records/-/raw/master/submit_here/adult.mypdns.cloud/tld.list"
+  },
+  {
+    "filterListId": 2567,
+    "id": 2818,
+    "primariness": 1,
+    "segmentNumber": 3,
+    "url": "https://mypdns.org/my-privacy-dns/porn-records/-/raw/master/submit_here/adult.mypdns.cloud/domains.list"
+  },
+  {
+    "filterListId": 2568,
+    "id": 2819,
+    "primariness": 2,
+    "segmentNumber": 3,
+    "url": "https://raw.githubusercontent.com/mypdns/porn-records/master/submit_here/adult.mypdns.cloud/domains.list"
+  },
+  {
+    "filterListId": 2569,
+    "id": 2820,
+    "primariness": 3,
+    "segmentNumber": 3,
+    "url": "https://raw.githubusercontent.com/porn-records/porn-records/master/submit_here/adult.mypdns.cloud/domains.list"
+  },
+  {
+    "filterListId": 2570,
+    "id": 2821,
+    "primariness": 4,
+    "segmentNumber": 3,
+    "url": "https://gitlab.com/MypDNS/porn-records/-/raw/master/submit_here/adult.mypdns.cloud/domains.list"
+  },
+  {
+    "filterListId": 2571,
+    "id": 2818,
+    "primariness": 1,
+    "segmentNumber": 4,
+    "url": "https://mypdns.org/my-privacy-dns/porn-records/-/raw/master/submit_here/adult.mypdns.cloud/hosts.list"
+  },
+  {
+    "filterListId": 2572,
+    "id": 2819,
+    "primariness": 2,
+    "segmentNumber": 4,
+    "url": "https://raw.githubusercontent.com/mypdns/porn-records/master/submit_here/adult.mypdns.cloud/hosts.list"
+  },
+  {
+    "filterListId": 2573,
+    "id": 2820,
+    "primariness": 3,
+    "segmentNumber": 4,
+    "url": "https://raw.githubusercontent.com/porn-records/porn-records/master/submit_here/adult.mypdns.cloud/hosts.list"
+  },
+  {
+    "filterListId": 2574,
+    "id": 2821,
+    "primariness": 4,
+    "segmentNumber": 4,
+    "url": "https://gitlab.com/MypDNS/porn-records/-/raw/master/submit_here/adult.mypdns.cloud/hosts.list"
+  },
+  {
+    "filterListId": 2575,
+    "id": 2818,
+    "primariness": 1,
+    "segmentNumber": 5,
+    "url": "https://mypdns.org/my-privacy-dns/porn-records/-/raw/master/submit_here/adult.mypdns.cloud/snuff.list"
+  },
+  {
+    "filterListId": 2576,
+    "id": 2819,
+    "primariness": 2,
+    "segmentNumber": 5,
+    "url": "https://raw.githubusercontent.com/mypdns/porn-records/master/submit_here/adult.mypdns.cloud/snuff.list"
+  },
+  {
+    "filterListId": 2577,
+    "id": 2820,
+    "primariness": 3,
+    "segmentNumber": 5,
+    "url": "https://raw.githubusercontent.com/porn-records/porn-records/master/submit_here/adult.mypdns.cloud/snuff.list"
+  },
+  {
+    "filterListId": 2578,
+    "id": 2821,
+    "primariness": 4,
+    "segmentNumber": 5,
+    "url": "https://gitlab.com/MypDNS/porn-records/-/raw/master/submit_here/adult.mypdns.cloud/snuff.list"
   }
 ]

--- a/services/Directory/data/Maintainer.json
+++ b/services/Directory/data/Maintainer.json
@@ -867,5 +867,25 @@
     "id": 167,
     "name": "PiQuark6046",
     "url": "https://github.com/piquark6046"
+  },
+  {
+    "id": 168,
+    "name": "spirillen",
+    "url": "https://mypdns.org/spirillen"
+  },
+  {
+    "id": 169,
+    "name": "Porn Records",
+    "url": "https://mypdns.org/porn-records"
+  },
+  {
+    "id": 170,
+    "name": "Razor (@RexAdev)",
+    "url": "https://mypdns.org/razor"
+  },
+  {
+    "id": 171,
+    "name": "Titom",
+    "url": "https://mypdns.org/Titomrock21"
   }
 ]


### PR DESCRIPTION
This commit should be covering NSFW records from [mypdns.org](https://mypdns.org/) to support
[RFC:952](http://tools.ietf.org/html/rfc952) blacklisting in ref to issue https://github.com/collinbarrett/FilterLists/issues/2819 by https://github.com/Rexadev

This commit should be adding the follow blacklist filters:
- adult.mypdns.cloud/domains.list
- adult.mypdns.cloud/hosts.list
- adult.mypdns.cloud/snuff.list
- adult.mypdns.cloud/wildcard.list
- adult.mypdns.cloud/tld.list

With mirror urls to the following base urls:
- https://mypdns.org/my-privacy-dns/porn-records (Master url)
- https://github.com/porn-records/porn-records/
- https://github.com/mypdns/porn-records/
- https://gitlab.com/MypDNS/porn-records/