### PR TITLE
Remove Anti-scam enhancer for 280blocker adblock filter and instead a…

### DIFF
--- a/services/Directory/FilterLists.Directory.Infrastructure.Migrations/Migrations/20220505102415_3001.Designer.cs
+++ b/services/Directory/FilterLists.Directory.Infrastructure.Migrations/Migrations/20220505102415_3001.Designer.cs
@@ -5,6 +5,7 @@ using FilterLists.Directory.Domain.Aggregates;
 using FilterLists.Directory.Infrastructure.Persistence.Queries.Context;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -13,9 +14,10 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace FilterLists.Directory.Infrastructure.Migrations.Migrations
 {
     [DbContext(typeof(QueryDbContext))]
-    partial class QueryDbContextModelSnapshot : ModelSnapshot
+    [Migration("20220505102415_3001")]
+    partial class _3001
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/services/Directory/FilterLists.Directory.Infrastructure.Migrations/Migrations/20220505102415_3001.cs
+++ b/services/Directory/FilterLists.Directory.Infrastructure.Migrations/Migrations/20220505102415_3001.cs
@@ -1,0 +1,83 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace FilterLists.Directory.Infrastructure.Migrations.Migrations
+{
+    public partial class _3001 : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DeleteData(
+                table: "filter_list_syntaxes",
+                keyColumns: new[] { "filter_list_id", "syntax_id" },
+                keyValues: new object[] { 2095L, 6L });
+
+            migrationBuilder.DeleteData(
+                table: "filter_list_tags",
+                keyColumns: new[] { "filter_list_id", "tag_id" },
+                keyValues: new object[] { 2095L, 6L });
+
+            migrationBuilder.InsertData(
+                table: "filter_list_syntaxes",
+                columns: new[] { "filter_list_id", "syntax_id" },
+                values: new object[] { 2095L, 3L });
+
+            migrationBuilder.InsertData(
+                table: "filter_list_tags",
+                columns: new[] { "filter_list_id", "tag_id" },
+                values: new object[] { 2095L, 10L });
+
+            migrationBuilder.UpdateData(
+                table: "filter_list_view_urls",
+                keyColumns: new[] { "filter_list_id", "id" },
+                keyValues: new object[] { 2095L, 2202L },
+                column: "url",
+                value: "https://raw.githubusercontent.com/Yuki2718/adblock/master/adguard/dns-unbreak.txt");
+
+            migrationBuilder.UpdateData(
+                table: "filter_lists",
+                keyColumn: "id",
+                keyValue: 2095L,
+                columns: new[] { "description", "license_id", "name" },
+                values: new object[] { "This list fixes known problems in AdGuard DNS filter mostly for Japanese user.", 8L, "AdGuard DNS filter Unbreaker for Japanese" });
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DeleteData(
+                table: "filter_list_syntaxes",
+                keyColumns: new[] { "filter_list_id", "syntax_id" },
+                keyValues: new object[] { 2095L, 3L });
+
+            migrationBuilder.DeleteData(
+                table: "filter_list_tags",
+                keyColumns: new[] { "filter_list_id", "tag_id" },
+                keyValues: new object[] { 2095L, 10L });
+
+            migrationBuilder.InsertData(
+                table: "filter_list_syntaxes",
+                columns: new[] { "filter_list_id", "syntax_id" },
+                values: new object[] { 2095L, 6L });
+
+            migrationBuilder.InsertData(
+                table: "filter_list_tags",
+                columns: new[] { "filter_list_id", "tag_id" },
+                values: new object[] { 2095L, 6L });
+
+            migrationBuilder.UpdateData(
+                table: "filter_list_view_urls",
+                keyColumns: new[] { "filter_list_id", "id" },
+                keyValues: new object[] { 2095L, 2202L },
+                column: "url",
+                value: "https://raw.githubusercontent.com/Yuki2718/adblock/master/japanese/280-patch.txt");
+
+            migrationBuilder.UpdateData(
+                table: "filter_lists",
+                keyColumn: "id",
+                keyValue: 2095L,
+                columns: new[] { "description", "license_id", "name" },
+                values: new object[] { "Enhance anti-scam capability of 280blocker adblock filter by utilizing advanced capability of AdGuard/uBlock Origin.", 28L, "Anti-scam enhancer for 280blocker adblock filter" });
+        }
+    }
+}

--- a/services/Directory/data/FilterList.json
+++ b/services/Directory/data/FilterList.json
@@ -13605,12 +13605,12 @@
     "name": "Yuki's uBlock Japanese filters - Annoyances"
   },
   {
-    "description": "Enhance anti-scam capability of 280blocker adblock filter by utilizing advanced capability of AdGuard/uBlock Origin.",
+    "description": "This list fixes known problems in AdGuard DNS filter mostly for Japanese user.",
     "homeUrl": "https://github.com/Yuki2718/adblock",
     "id": 2095,
     "issuesUrl": "https://github.com/Yuki2718/adblock/issues",
-    "licenseId": 28,
-    "name": "Anti-scam enhancer for 280blocker adblock filter"
+    "licenseId": 8,
+    "name": "AdGuard DNS filter Unbreaker for Japanese"
   },
   {
     "description": "Removes blogroll (feed-style mutual links) on Japanese sites. Included in Yuki's uBlock Japanese filters - Annoyances",

--- a/services/Directory/data/FilterListSyntax.json
+++ b/services/Directory/data/FilterListSyntax.json
@@ -6845,7 +6845,7 @@
   },
   {
     "filterListId": 2095,
-    "syntaxId": 6
+    "syntaxId": 3
   },
   {
     "filterListId": 2096,

--- a/services/Directory/data/FilterListTag.json
+++ b/services/Directory/data/FilterListTag.json
@@ -10209,7 +10209,7 @@
   },
   {
     "filterListId": 2095,
-    "tagId": 6
+    "tagId": 10
   },
   {
     "filterListId": 2096,

--- a/services/Directory/data/FilterListViewUrl.json
+++ b/services/Directory/data/FilterListViewUrl.json
@@ -12561,7 +12561,7 @@
     "filterListId": 2095,
     "id": 2202,
     "primariness": 1,
-    "url": "https://raw.githubusercontent.com/Yuki2718/adblock/master/japanese/280-patch.txt"
+    "url": "https://raw.githubusercontent.com/Yuki2718/adblock/master/adguard/dns-unbreak.txt"
   },
   {
     "filterListId": 2099,


### PR DESCRIPTION
…dd AdGuard DNS filter Unbreaker for Japanese
I'm going to deprecate Anti-scam enhancer for 280blocker adblock filter. Replaced by the new list I added by reusing its ID.