### PR TITLE
Remove blogmangit Cosmetic-Filters

### DIFF
--- a/services/Directory/FilterLists.Directory.Infrastructure.Migrations/Migrations/20230816214511_3791.Designer.cs
+++ b/services/Directory/FilterLists.Directory.Infrastructure.Migrations/Migrations/20230816214511_3791.Designer.cs
@@ -5,6 +5,7 @@ using FilterLists.Directory.Domain.Aggregates;
 using FilterLists.Directory.Infrastructure.Persistence.Queries.Context;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -13,9 +14,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace FilterLists.Directory.Infrastructure.Migrations.Migrations
 {
     [DbContext(typeof(QueryDbContext))]
-    partial class QueryDbContextModelSnapshot : ModelSnapshot
+    [Migration("20230816214511_3791")]
+    partial class _3791
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/services/Directory/FilterLists.Directory.Infrastructure.Migrations/Migrations/20230816214511_3791.cs
+++ b/services/Directory/FilterLists.Directory.Infrastructure.Migrations/Migrations/20230816214511_3791.cs
@@ -1,0 +1,58 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace FilterLists.Directory.Infrastructure.Migrations.Migrations
+{
+    /// <inheritdoc />
+    public partial class _3791 : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DeleteData(
+                table: "filter_list_syntaxes",
+                keyColumns: new[] { "filter_list_id", "syntax_id" },
+                keyValues: new object[] { 2601L, 3L });
+
+            migrationBuilder.DeleteData(
+                table: "filter_list_tags",
+                keyColumns: new[] { "filter_list_id", "tag_id" },
+                keyValues: new object[] { 2601L, 9L });
+
+            migrationBuilder.DeleteData(
+                table: "filter_list_view_urls",
+                keyColumns: new[] { "filter_list_id", "id" },
+                keyValues: new object[] { 2601L, 2866L });
+
+            migrationBuilder.DeleteData(
+                table: "filter_lists",
+                keyColumn: "id",
+                keyValue: 2601L);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.InsertData(
+                table: "filter_lists",
+                columns: new[] { "id", "chat_url", "description", "donate_url", "email_address", "forum_url", "home_url", "is_approved", "issues_url", "name", "onion_url", "policy_url", "submission_url" },
+                values: new object[] { 2601L, null, "Some custom cosmetic filters to be used for ublock origin & adguard. This filter is mainly for mobile browsing specifically for heavily modified AMP pages. Beware that this filter is very aggressive filters which disables the following from an webpage and is very effective if used with uBlock Origin and AdGuard.", null, null, null, "https://github.com/blogmangit/Cosmetic-Filters", true, null, "blogmangit Cosmetic-Filters", null, null, null });
+
+            migrationBuilder.InsertData(
+                table: "filter_list_syntaxes",
+                columns: new[] { "filter_list_id", "syntax_id" },
+                values: new object[] { 2601L, 3L });
+
+            migrationBuilder.InsertData(
+                table: "filter_list_tags",
+                columns: new[] { "filter_list_id", "tag_id" },
+                values: new object[] { 2601L, 9L });
+
+            migrationBuilder.InsertData(
+                table: "filter_list_view_urls",
+                columns: new[] { "filter_list_id", "id", "primariness", "url" },
+                values: new object[] { 2601L, 2866L, (short)1, "https://raw.githubusercontent.com/blogmangit/Cosmetic-Filters/main/cosmetic filters.txt" });
+        }
+    }
+}

--- a/services/Directory/data/FilterList.json
+++ b/services/Directory/data/FilterList.json
@@ -16846,12 +16846,6 @@
     "name": "Scam Links - Links"
   },
   {
-    "description": "Some custom cosmetic filters to be used for ublock origin & adguard. This filter is mainly for mobile browsing specifically for heavily modified AMP pages. Beware that this filter is very aggressive filters which disables the following from an webpage and is very effective if used with uBlock Origin and AdGuard.",
-    "homeUrl": "https://github.com/blogmangit/Cosmetic-Filters",
-    "id": 2601,
-    "name": "blogmangit Cosmetic-Filters"
-  },
-  {
     "description": "Adblocker list (experimental) which allows you to read articles from (supported) sites that implement a paywall. For some sites it will log you out (or block you to log in); caused by removing cookies or blocking general paywall-scripts. Disclaimer: the list doesn't support as many sites as the extension/add-on though.",
     "homeUrl": "https://gitlab.com/magnolia1234/bypass-paywalls-clean-filters",
     "id": 2603,

--- a/services/Directory/data/FilterListSyntax.json
+++ b/services/Directory/data/FilterListSyntax.json
@@ -8432,10 +8432,6 @@
     "syntaxId": 2
   },
   {
-    "filterListId": 2601,
-    "syntaxId": 3
-  },
-  {
     "filterListId": 2603,
     "syntaxId": 4
   },

--- a/services/Directory/data/FilterListTag.json
+++ b/services/Directory/data/FilterListTag.json
@@ -12396,10 +12396,6 @@
     "tagId": 6
   },
   {
-    "filterListId": 2601,
-    "tagId": 9
-  },
-  {
     "filterListId": 2603,
     "tagId": 40
   },

--- a/services/Directory/data/FilterListViewUrl.json
+++ b/services/Directory/data/FilterListViewUrl.json
@@ -15621,12 +15621,6 @@
     "url": "https://raw.githubusercontent.com/DevSpen/links/master/src/links.txt"
   },
   {
-    "filterListId": 2601,
-    "id": 2866,
-    "primariness": 1,
-    "url": "https://raw.githubusercontent.com/blogmangit/Cosmetic-Filters/main/cosmetic%20filters.txt"
-  },
-  {
     "filterListId": 2603,
     "id": 2867,
     "primariness": 1,


### PR DESCRIPTION
This filterlist appears to have been deleted<sup>[[1]](https://github.com/blogmangit/Cosmetic-Filters/commit/4f1edae9d43985d67ff33dc39106337f89fa1e0d)</sup>. The maintainer has created a new file, but it is unclear if that list is related or designed to replace the original<sup>[[2]](https://github.com/blogmangit/Cosmetic-Filters/commits/main/adguard_cb_user_filter_1667069852317.txt)</sup>. It is also small and rarely updated.
I can readd it with the new name, but for now I have just deleted it.