### PR TITLE
Remove OwlStudio ABP Rules

### DIFF
--- a/services/Directory/FilterLists.Directory.Infrastructure.Migrations/Migrations/20230825224322_3805.Designer.cs
+++ b/services/Directory/FilterLists.Directory.Infrastructure.Migrations/Migrations/20230825224322_3805.Designer.cs
@@ -5,6 +5,7 @@ using FilterLists.Directory.Domain.Aggregates;
 using FilterLists.Directory.Infrastructure.Persistence.Queries.Context;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -13,9 +14,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace FilterLists.Directory.Infrastructure.Migrations.Migrations
 {
     [DbContext(typeof(QueryDbContext))]
-    partial class QueryDbContextModelSnapshot : ModelSnapshot
+    [Migration("20230825224322_3805")]
+    partial class _3805
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/services/Directory/FilterLists.Directory.Infrastructure.Migrations/Migrations/20230825224322_3805.cs
+++ b/services/Directory/FilterLists.Directory.Infrastructure.Migrations/Migrations/20230825224322_3805.cs
@@ -1,0 +1,79 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+#pragma warning disable CA1814 // Prefer jagged arrays over multidimensional
+
+namespace FilterLists.Directory.Infrastructure.Migrations.Migrations
+{
+    /// <inheritdoc />
+    public partial class _3805 : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DeleteData(
+                table: "filter_list_languages",
+                keyColumns: new[] { "filter_list_id", "language_id" },
+                keyValues: new object[] { 767L, 37L });
+
+            migrationBuilder.DeleteData(
+                table: "filter_list_languages",
+                keyColumns: new[] { "filter_list_id", "language_id" },
+                keyValues: new object[] { 767L, 179L });
+
+            migrationBuilder.DeleteData(
+                table: "filter_list_syntaxes",
+                keyColumns: new[] { "filter_list_id", "syntax_id" },
+                keyValues: new object[] { 767L, 3L });
+
+            migrationBuilder.DeleteData(
+                table: "filter_list_tags",
+                keyColumns: new[] { "filter_list_id", "tag_id" },
+                keyValues: new object[] { 767L, 2L });
+
+            migrationBuilder.DeleteData(
+                table: "filter_list_view_urls",
+                keyColumns: new[] { "filter_list_id", "id" },
+                keyValues: new object[] { 767L, 798L });
+
+            migrationBuilder.DeleteData(
+                table: "filter_lists",
+                keyColumn: "id",
+                keyValue: 767L);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.InsertData(
+                table: "filter_lists",
+                columns: new[] { "id", "chat_url", "description", "donate_url", "email_address", "forum_url", "home_url", "is_approved", "issues_url", "license_id", "name", "onion_url", "policy_url", "submission_url" },
+                values: new object[] { 767L, null, "Rules contributed by diligent owls.", null, null, null, "https://github.com/OwlStudioCN/owl-abp-rules", true, "https://github.com/OwlStudioCN/owl-abp-rules/issues", 8L, "OwlStudio ABP Rules", null, null, null });
+
+            migrationBuilder.InsertData(
+                table: "filter_list_languages",
+                columns: new[] { "filter_list_id", "language_id" },
+                values: new object[,]
+                {
+                    { 767L, 37L },
+                    { 767L, 179L }
+                });
+
+            migrationBuilder.InsertData(
+                table: "filter_list_syntaxes",
+                columns: new[] { "filter_list_id", "syntax_id" },
+                values: new object[] { 767L, 3L });
+
+            migrationBuilder.InsertData(
+                table: "filter_list_tags",
+                columns: new[] { "filter_list_id", "tag_id" },
+                values: new object[] { 767L, 2L });
+
+            migrationBuilder.InsertData(
+                table: "filter_list_view_urls",
+                columns: new[] { "filter_list_id", "id", "primariness", "url" },
+                values: new object[] { 767L, 798L, (short)1, "https://raw.githubusercontent.com/OwlStudioCN/owl-abp-rules/master/owl-abp-rules.txt" });
+        }
+    }
+}

--- a/services/Directory/data/FilterList.json
+++ b/services/Directory/data/FilterList.json
@@ -4376,14 +4376,6 @@
     "name": "lilydjwg's rules"
   },
   {
-    "description": "Rules contributed by diligent owls.",
-    "homeUrl": "https://github.com/OwlStudioCN/owl-abp-rules",
-    "id": 767,
-    "issuesUrl": "https://github.com/OwlStudioCN/owl-abp-rules/issues",
-    "licenseId": 8,
-    "name": "OwlStudio ABP Rules"
-  },
-  {
     "description": "A filter list for Adblock Plus for remove all newsletters banners",
     "homeUrl": "https://github.com/Manu1400/i-don-t-care-about-newsletters",
     "id": 769,

--- a/services/Directory/data/FilterListLanguage.json
+++ b/services/Directory/data/FilterListLanguage.json
@@ -976,14 +976,6 @@
     "languageId": 179
   },
   {
-    "filterListId": 767,
-    "languageId": 37
-  },
-  {
-    "filterListId": 767,
-    "languageId": 179
-  },
-  {
     "filterListId": 769,
     "languageId": 47
   },

--- a/services/Directory/data/FilterListSyntax.json
+++ b/services/Directory/data/FilterListSyntax.json
@@ -2176,10 +2176,6 @@
     "syntaxId": 3
   },
   {
-    "filterListId": 767,
-    "syntaxId": 3
-  },
-  {
     "filterListId": 769,
     "syntaxId": 3
   },

--- a/services/Directory/data/FilterListTag.json
+++ b/services/Directory/data/FilterListTag.json
@@ -3196,10 +3196,6 @@
     "tagId": 2
   },
   {
-    "filterListId": 767,
-    "tagId": 2
-  },
-  {
     "filterListId": 769,
     "tagId": 28
   },

--- a/services/Directory/data/FilterListViewUrl.json
+++ b/services/Directory/data/FilterListViewUrl.json
@@ -4572,12 +4572,6 @@
     "url": "https://raw.githubusercontent.com/lilydjwg/abp-rules/master/list.txt"
   },
   {
-    "filterListId": 767,
-    "id": 798,
-    "primariness": 1,
-    "url": "https://raw.githubusercontent.com/OwlStudioCN/owl-abp-rules/master/owl-abp-rules.txt"
-  },
-  {
     "filterListId": 769,
     "id": 799,
     "primariness": 1,


### PR DESCRIPTION
Remove OwlStudio ABP Rules, as it seems to no longer exist.