### PR TITLE
refactor: ♻️ specify alt js id to try avoid cql branch alert

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -24,7 +24,7 @@ jobs:
         include:
           - language: csharp
             build-mode: autobuild
-          - language: javascript-typescript
+          - language: javascript
             build-mode: none
     steps:
       - name: Checkout repository


### PR DESCRIPTION
try avoiding weird branch alerts like [this](https://github.com/collinbarrett/FilterLists/pull/4303/checks?check_run_id=25513910045) despite `javascript` supposedly being identical to `javascript-typescript` ([ref](https://docs.github.com/en/enterprise-cloud@latest/code-security/codeql-cli/getting-started-with-the-codeql-cli/preparing-your-code-for-codeql-analysis#running-codeql-database-create)).