### PR TITLE
add github-less-social uBO

### DIFF
--- a/services/Directory/data/FilterList.json
+++ b/services/Directory/data/FilterList.json
@@ -17860,5 +17860,29 @@
     "issuesUrl": "https://github.com/touhidurrr/malicious-hosts-bd/issues",
     "licenseId": 10,
     "name": "Malicious Hosts BD"
+  },
+  {
+    "chatUrl": "xmpp:github-less-social@chat.toastal.in.th?join",
+    "description": "Removes social, upsells, & AI features from the proprietary MS GitHub Git forge, directly-adjacent Microsoft-owned platforms, & some adjacent services using this platform to integrate social features.",
+    "donateUrl": "https://toast.al/funding/",
+    "emailAddress": "~toastal/github-less-social@lists.sr.ht",
+    "homeUrl": "https://codeberg.org/toastal/github-less-social",
+    "id": 2729,
+    "issuesUrl": "https://codeberg.org/toastal/github-less-social/issues",
+    "licenseId": 37,
+    "name": "Microsoft GitHub Less Social",
+    "submissionUrl": "https://codeberg.org/toastal/github-less-social#pitching-in"
+  },
+  {
+    "chatUrl": "xmpp:github-less-social@chat.toastal.in.th?join",
+    "description": "Aggressively removes social, upsells & AI features from the proprietary MS GitHub Git forge, directly-adjacent Microsoft-owned platforms, & some adjacent services using this platform to integrate social features.",
+    "donateUrl": "https://toast.al/funding/",
+    "emailAddress": "~toastal/github-less-social@lists.sr.ht",
+    "homeUrl": "https://codeberg.org/toastal/github-less-social",
+    "id": 2730,
+    "issuesUrl": "https://codeberg.org/toastal/github-less-social/issues",
+    "licenseId": 37,
+    "name": "Microsoft GitHub Less Social",
+    "submissionUrl": "https://codeberg.org/toastal/github-less-social#pitching-in"
   }
 ]

--- a/services/Directory/data/FilterListLanguage.json
+++ b/services/Directory/data/FilterListLanguage.json
@@ -3514,5 +3514,13 @@
   {
     "filterListId": 2728,
     "languageId": 37
+  },
+  {
+    "filterListId": 2729,
+    "languageId": 37
+  },
+  {
+    "filterListId": 2730,
+    "languageId": 37
   }
 ]

--- a/services/Directory/data/FilterListMaintainer.json
+++ b/services/Directory/data/FilterListMaintainer.json
@@ -6106,5 +6106,13 @@
   {
     "filterListId": 2728,
     "maintainerId": 196
+  },
+  {
+    "filterListId": 2729,
+    "maintainerId": 197
+  },
+  {
+    "filterListId": 2730,
+    "maintainerId": 197
   }
 ]

--- a/services/Directory/data/FilterListSyntax.json
+++ b/services/Directory/data/FilterListSyntax.json
@@ -9050,5 +9050,17 @@
   {
     "filterListId": 2728,
     "syntaxId": 2
+  },
+  {
+    "filterListId": 2729,
+    "syntaxId": 4
+  },
+  {
+    "filterListId": 2730,
+    "syntaxId": 4
+  },
+  {
+    "filterListId": 2730,
+    "syntaxId": 21
   }
 ]

--- a/services/Directory/data/FilterListTag.json
+++ b/services/Directory/data/FilterListTag.json
@@ -12982,5 +12982,33 @@
   {
     "filterListId": 2728,
     "tagId": 7
+  },
+  {
+    "filterListId": 2729,
+    "tagId": 3
+  },
+  {
+    "filterListId": 2729,
+    "tagId": 19
+  },
+  {
+    "filterListId": 2729,
+    "tagId": 35
+  },
+  {
+    "filterListId": 2730,
+    "tagId": 3
+  },
+  {
+    "filterListId": 2730,
+    "tagId": 9
+  },
+  {
+    "filterListId": 2730,
+    "tagId": 19
+  },
+  {
+    "filterListId": 2730,
+    "tagId": 35
   }
 ]

--- a/services/Directory/data/FilterListViewUrl.json
+++ b/services/Directory/data/FilterListViewUrl.json
@@ -16773,5 +16773,29 @@
     "id": 3061,
     "primariness": 1,
     "url": "https://raw.githubusercontent.com/touhidurrr/malicious-hosts-bd/main/domains.txt"
+  },
+  {
+    "filterListId": 2729,
+    "id": 3062,
+    "primariness": 1,
+    "url": "https://codeberg.org/toastal/github-less-social/raw/branch/trunk/list.txt"
+  },
+  {
+    "filterListId": 2730,
+    "id": 3062,
+    "primariness": 1,
+    "url": "https://codeberg.org/toastal/github-less-social/raw/branch/trunk/aggressive.txt"
+  },
+  {
+    "filterListId": 2729,
+    "id": 3063,
+    "primariness": 2,
+    "url": "https://git.sr.ht/~toastal/github-less-social/blob/trunk/list.txt"
+  },
+  {
+    "filterListId": 2730,
+    "id": 3063,
+    "primariness": 2,
+    "url": "https://git.sr.ht/~toastal/github-less-social/blob/trunk/aggressive.txt"
   }
 ]

--- a/services/Directory/data/Maintainer.json
+++ b/services/Directory/data/Maintainer.json
@@ -1013,5 +1013,10 @@
     "id": 196,
     "name": "Md. Touhidur Rahman",
     "url": "তৌহিদুর.বাংলা"
+  },
+  {
+    "id": 197,
+    "name": "toastal",
+    "url": "https://toast.al"
   }
 ]

--- a/services/Directory/data/lint.sh
+++ b/services/Directory/data/lint.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Sorts json files by FilterLists conventions documented in Wiki.
 
 jq -S ".|=sort_by(.dependencyFilterListId, .dependentFilterListId)" Dependent.json > Dependent.tmp


### PR DESCRIPTION
Adds [Microsoft GitHub Less Social](https://codeberg.org/toastal/github-less-social) uBlock Origin rules.

[^1]

[^1]: Please consider [giving up MS GitHub](https://sfconservancy.org/GiveUpGitHub/) or offering a non-proprietary, non-US-corporate-controlled mirror for this free software project. I wish to delete this Microsoft account in the future, but I need more projects like this to support alternative methods to send patches & contribute.