### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -120,6 +120,9 @@ jobs:
 
     runs-on: ubuntu-latest
 
+    permissions:
+      contents: read
+
     if: github.event_name == 'pull_request' && github.event.action == 'closed'
 
     steps:


### PR DESCRIPTION
Potential fix for [https://github.com/collinbarrett/FilterLists/security/code-scanning/5](https://github.com/collinbarrett/FilterLists/security/code-scanning/5)

To fix the issue, we will add a `permissions` block to the `close_pull_request` job. Since this job only uses the `Azure/static-web-apps-deploy@v1` action to close a pull request, it does not require write access to repository contents or other elevated permissions. We will set the permissions to `contents: read` as a minimal starting point, which is sufficient for most workflows unless additional permissions are explicitly required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
