### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/directory.yml
+++ b/.github/workflows/directory.yml
@@ -73,6 +73,9 @@ jobs:
 
     needs: build
 
+    permissions:
+      contents: read
+
     if: github.event_name == 'push'
 
     env:


### PR DESCRIPTION
Potential fix for [https://github.com/collinbarrett/FilterLists/security/code-scanning/3](https://github.com/collinbarrett/FilterLists/security/code-scanning/3)

To fix the issue, we will add a `permissions` block to the `deploy` job. Since the `deploy` job uses the `azure/webapps-deploy` action, it does not require write permissions to the repository or other resources. A minimal `permissions` block with `contents: read` will suffice, as the job does not perform any actions that require additional permissions.

The changes will be made in the `.github/workflows/directory.yml` file, specifically within the `deploy` job definition.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
