### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -21,6 +21,10 @@ jobs:
 
     runs-on: ubuntu-latest
 
+    permissions:
+      contents: read
+      id-token: write
+
     if: github.event_name == 'pull_request' && github.event.action != 'closed'
 
     environment:


### PR DESCRIPTION
Potential fix for [https://github.com/collinbarrett/FilterLists/security/code-scanning/2](https://github.com/collinbarrett/FilterLists/security/code-scanning/2)

To fix the issue, we need to add a `permissions` block to the `build_and_deploy_staging` job. This block should specify the minimal permissions required for the job to function correctly. Based on the workflow's actions, the job likely only needs `contents: read` permissions to access repository contents and `id-token: write` permissions for authentication purposes.

The `permissions` block should be added directly under the job definition (`build_and_deploy_staging`) to ensure it applies only to this job and does not affect other jobs in the workflow.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
