### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -79,6 +79,10 @@ jobs:
 
     runs-on: ubuntu-latest
 
+    permissions:
+      contents: read
+      id-token: write
+
     if: github.event_name == 'push'
 
     environment:


### PR DESCRIPTION
Potential fix for [https://github.com/collinbarrett/FilterLists/security/code-scanning/4](https://github.com/collinbarrett/FilterLists/security/code-scanning/4)

To fix the issue, we need to add a `permissions` block to the `build_and_deploy_production` job. Based on the actions performed in this job, the minimal required permissions are `contents: read` and `id-token: write`. The `contents: read` permission is needed for accessing the repository's contents, and the `id-token: write` permission is required for authentication with Azure Static Web Apps.

The `permissions` block should be added immediately after the `runs-on` key in the `build_and_deploy_production` job.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
