### PR TITLE
Potential fix for code scanning alert no. 6: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/directory.yml
+++ b/.github/workflows/directory.yml
@@ -68,6 +68,10 @@ jobs:
 
     runs-on: ubuntu-latest
 
+    permissions:
+      contents: read
+      packages: read
+
     needs: build
 
     if: github.event_name == 'push'


### PR DESCRIPTION
Potential fix for [https://github.com/collinbarrett/FilterLists/security/code-scanning/6](https://github.com/collinbarrett/FilterLists/security/code-scanning/6)

To fix the issue, we will add a `permissions` block to the `deploy` job. This block will explicitly define the minimal permissions required for the job to function. Based on the job's functionality, it likely requires `contents: read` to access the repository's contents and `packages: read` to pull the Docker image from the container registry. No write permissions are necessary for this job.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
