### PR TITLE
Add AdVoid filter lists

### DIFF
--- a/services/Directory/data/FilterList.json
+++ b/services/Directory/data/FilterList.json
@@ -18646,5 +18646,15 @@
     "donateUrl": "https://ko-fi.com/igorskyflyer",
     "emailAddress": "support@igorskyflyer.me",
     "name": "AdVoid.Addon.NoExternals"
+  },
+  {
+    "description": "Blocks non-essential resources: news widgets, JavaScript and CSS maps, PWA install banners, SWF objects, etc.",
+    "homeUrl": "https://github.com/the-advoid/ad-void",
+    "id": 2833,
+    "issuesUrl": "https://github.com/the-advoid/ad-void/issues",
+    "licenseId": 4,
+    "donateUrl": "https://ko-fi.com/igorskyflyer",
+    "emailAddress": "support@igorskyflyer.me",
+    "name": "AdVoid.Addon.NoExtras"
   }
 ]

--- a/services/Directory/data/FilterList.json
+++ b/services/Directory/data/FilterList.json
@@ -18597,7 +18597,7 @@
     "licenseId": 4,
     "name": "Meta Dnsmasq"
   },
-    {
+  {
     "description": "Blocks intrusive ads, trackers, fake downloads, cookie prompts, overlays, push alerts, widgets, and obsolete web clutter.",
     "homeUrl": "https://github.com/the-advoid/ad-void",
     "id": 2828,
@@ -18606,5 +18606,15 @@
     "donateUrl": "https://ko-fi.com/igorskyflyer",
     "emailAddress": "support@igorskyflyer.me",
     "name": "AdVoid.Full"
+  },
+  {
+    "description": "Blocks major ad-servers, trackers, malware, fake download links, cuts-down timer executions.",
+    "homeUrl": "https://github.com/the-advoid/ad-void",
+    "id": 2829,
+    "issuesUrl": "https://github.com/the-advoid/ad-void/issues",
+    "licenseId": 4,
+    "donateUrl": "https://ko-fi.com/igorskyflyer",
+    "emailAddress": "support@igorskyflyer.me",
+    "name": "AdVoid.Core"
   }
 ]

--- a/services/Directory/data/FilterList.json
+++ b/services/Directory/data/FilterList.json
@@ -18596,5 +18596,13 @@
     "issuesUrl": "https://github.com/Bundy01/meta-blocklists/issues",
     "licenseId": 4,
     "name": "Meta Dnsmasq"
+  },
+    {
+    "description": "Blocks intrusive ads, trackers, fake downloads, cookie prompts, overlays, push alerts, widgets, and obsolete web clutter.",
+    "homeUrl": "https://github.com/the-advoid/ad-void",
+    "id": 2828,
+    "issuesUrl": "https://github.com/the-advoid/ad-void/issues",
+    "licenseId": 4,
+    "name": "AdVoid.Full"
   }
 ]

--- a/services/Directory/data/FilterList.json
+++ b/services/Directory/data/FilterList.json
@@ -18636,5 +18636,15 @@
     "donateUrl": "https://ko-fi.com/igorskyflyer",
     "emailAddress": "support@igorskyflyer.me",
     "name": "AdVoid.Addon.NoAnnoyances"
+  },
+  {
+    "description": "Blocks external features: sharing, Google Chromecast, popup chats, post widgets, like widgets, etc.",
+    "homeUrl": "https://github.com/the-advoid/ad-void",
+    "id": 2832,
+    "issuesUrl": "https://github.com/the-advoid/ad-void/issues",
+    "licenseId": 4,
+    "donateUrl": "https://ko-fi.com/igorskyflyer",
+    "emailAddress": "support@igorskyflyer.me",
+    "name": "AdVoid.Addon.NoExternals"
   }
 ]

--- a/services/Directory/data/FilterList.json
+++ b/services/Directory/data/FilterList.json
@@ -18616,5 +18616,15 @@
     "donateUrl": "https://ko-fi.com/igorskyflyer",
     "emailAddress": "support@igorskyflyer.me",
     "name": "AdVoid.Core"
+  },
+  {
+    "description": "DNS-level blocker for ads, trackers, telemetry, malware, and web nuisances. Lightweight, system-wide protection.",
+    "homeUrl": "https://github.com/the-advoid/ad-void",
+    "id": 2830,
+    "issuesUrl": "https://github.com/the-advoid/ad-void/issues",
+    "licenseId": 4,
+    "donateUrl": "https://ko-fi.com/igorskyflyer",
+    "emailAddress": "support@igorskyflyer.me",
+    "name": "AdVoid.DNS"
   }
 ]

--- a/services/Directory/data/FilterList.json
+++ b/services/Directory/data/FilterList.json
@@ -18626,5 +18626,15 @@
     "donateUrl": "https://ko-fi.com/igorskyflyer",
     "emailAddress": "support@igorskyflyer.me",
     "name": "AdVoid.DNS"
+  },
+  {
+    "description": "Blocks site annoyances: cookie-consent banners, popups, modals, push notifications, survey, newsletter and subscribe popups, rating dialogs, skips countdowns, etc.",
+    "homeUrl": "https://github.com/the-advoid/ad-void",
+    "id": 2831,
+    "issuesUrl": "https://github.com/the-advoid/ad-void/issues",
+    "licenseId": 4,
+    "donateUrl": "https://ko-fi.com/igorskyflyer",
+    "emailAddress": "support@igorskyflyer.me",
+    "name": "AdVoid.Addon.NoAnnoyances"
   }
 ]

--- a/services/Directory/data/FilterList.json
+++ b/services/Directory/data/FilterList.json
@@ -18603,6 +18603,8 @@
     "id": 2828,
     "issuesUrl": "https://github.com/the-advoid/ad-void/issues",
     "licenseId": 4,
+    "donateUrl": "https://ko-fi.com/igorskyflyer",
+    "emailAddress": "support@igorskyflyer.me",
     "name": "AdVoid.Full"
   }
 ]

--- a/services/Directory/data/FilterListLanguage.json
+++ b/services/Directory/data/FilterListLanguage.json
@@ -3582,5 +3582,5 @@
   {
     "filterListId": 2833,
     "languageId": 37
-  },
+  }
 ]

--- a/services/Directory/data/FilterListLanguage.json
+++ b/services/Directory/data/FilterListLanguage.json
@@ -3558,5 +3558,29 @@
   {
     "filterListId": 2818,
     "languageId": 171
-  }
+  },
+  {
+    "filterListId": 2828,
+    "languageId": 37
+  },
+  {
+    "filterListId": 2829,
+    "languageId": 37
+  },
+  {
+    "filterListId": 2830,
+    "languageId": 37
+  },
+  {
+    "filterListId": 2831,
+    "languageId": 37
+  },
+  {
+    "filterListId": 2832,
+    "languageId": 37
+  },
+  {
+    "filterListId": 2833,
+    "languageId": 37
+  },
 ]

--- a/services/Directory/data/FilterListMaintainer.json
+++ b/services/Directory/data/FilterListMaintainer.json
@@ -6410,5 +6410,29 @@
   {
     "filterListId": 2827,
     "maintainerId": 198
+  },
+  {
+    "filterListId": 2828,
+    "maintainerId": 207
+  },
+  {
+    "filterListId": 2829,
+    "maintainerId": 207
+  },
+  {
+    "filterListId": 2830,
+    "maintainerId": 207
+  },
+  {
+    "filterListId": 2831,
+    "maintainerId": 207
+  },
+  {
+    "filterListId": 2832,
+    "maintainerId": 207
+  },
+  {
+    "filterListId": 2833,
+    "maintainerId": 207
   }
 ]

--- a/services/Directory/data/FilterListSyntax.json
+++ b/services/Directory/data/FilterListSyntax.json
@@ -9330,5 +9330,29 @@
   {
     "filterListId": 2827,
     "syntaxId": 20
+  },
+  {
+    "filterListId": 2828,
+    "syntaxId": 4
+  },
+  {
+    "filterListId": 2829,
+    "syntaxId": 4
+  },
+  {
+    "filterListId": 2830,
+    "syntaxId": 2
+  },
+  {
+    "filterListId": 2831,
+    "syntaxId": 4
+  },
+  {
+    "filterListId": 2832,
+    "syntaxId": 4
+  },
+  {
+    "filterListId": 2833,
+    "syntaxId": 4
   }
 ]

--- a/services/Directory/data/FilterListTag.json
+++ b/services/Directory/data/FilterListTag.json
@@ -13282,5 +13282,29 @@
   {
     "filterListId": 2827,
     "tagId": 19
+  },
+  {
+    "filterListId": 2828,
+    "tagId": 3
+  },
+  {
+    "filterListId": 2829,
+    "tagId": 2
+  },
+  {
+    "filterListId": 2830,
+    "tagId": 6
+  },
+  {
+    "filterListId": 2831,
+    "tagId": 9
+  },
+  {
+    "filterListId": 2832,
+    "tagId": 4
+  },
+  {
+    "filterListId": 2833,
+    "tagId": 9
   }
 ]

--- a/services/Directory/data/FilterListViewUrl.json
+++ b/services/Directory/data/FilterListViewUrl.json
@@ -17683,5 +17683,77 @@
     "id": 3218,
     "primariness": 1,
     "url": "https://raw.githubusercontent.com/Bundy01/meta-blocklists/main/meta-dnsmasq.txt"
+  },
+  {
+    "filterListId": 2828,
+    "id": 3219,
+    "primariness": 1,
+    "url": "https://raw.githubusercontent.com/the-advoid/ad-void/main/AdVoid.Full.txt"
+  },
+  {
+    "filterListId": 2828,
+    "id": 3220,
+    "primariness": 2,
+    "url": "https://cdn.jsdelivr.net/gh/the-advoid/ad-void@main/AdVoid.Full.txt"
+  },
+  {
+    "filterListId": 2829,
+    "id": 3221,
+    "primariness": 1,
+    "url": "https://raw.githubusercontent.com/the-advoid/ad-void/main/AdVoid.Core.txt"
+  },
+  {
+    "filterListId": 2829,
+    "id": 3222,
+    "primariness": 2,
+    "url": "https://cdn.jsdelivr.net/gh/the-advoid/ad-void@main/AdVoid.Core.txt"
+  },
+  {
+    "filterListId": 2830,
+    "id": 3223,
+    "primariness": 1,
+    "url": "https://raw.githubusercontent.com/the-advoid/ad-void/main/AdVoid.DNS.txt"
+  },
+  {
+    "filterListId": 2830,
+    "id": 3224,
+    "primariness": 2,
+    "url": "https://cdn.jsdelivr.net/gh/the-advoid/ad-void@main/AdVoid.DNS.txt"
+  },
+  {
+    "filterListId": 2831,
+    "id": 3225,
+    "primariness": 1,
+    "url": "https://raw.githubusercontent.com/the-advoid/ad-void/main/add-ons/AdVoid.Addon.NoAnnoyances.txt"
+  },
+  {
+    "filterListId": 2831,
+    "id": 3226,
+    "primariness": 2,
+    "url": "https://cdn.jsdelivr.net/gh/the-advoid/ad-void@main/add-ons/AdVoid.Addon.NoAnnoyances.txt"
+  },
+  {
+    "filterListId": 2832,
+    "id": 3227,
+    "primariness": 1,
+    "url": "https://raw.githubusercontent.com/the-advoid/ad-void/main/add-ons/AdVoid.Addon.NoExternals.txt"
+  },
+  {
+    "filterListId": 2832,
+    "id": 3228,
+    "primariness": 2,
+    "url": "https://cdn.jsdelivr.net/gh/the-advoid/ad-void@main/add-ons/AdVoid.Addon.NoExternals.txt"
+  },
+  {
+    "filterListId": 2833,
+    "id": 3229,
+    "primariness": 1,
+    "url": "https://raw.githubusercontent.com/the-advoid/ad-void/main/add-ons/AdVoid.Addon.NoExtras.txt"
+  },
+  {
+    "filterListId": 2833,
+    "id": 3230,
+    "primariness": 2,
+    "url": "https://cdn.jsdelivr.net/gh/the-advoid/ad-void@main/add-ons/AdVoid.Addon.NoExtras.txt"
   }
 ]

--- a/services/Directory/data/Maintainer.json
+++ b/services/Directory/data/Maintainer.json
@@ -1064,5 +1064,12 @@
     "id": 206,
     "name": "1275.ru",
     "url": "https://1275.ru/"
+  },
+   {
+    "id": 207,
+    "name": "Igor Dimitrijević (igorskyflyer)",
+    "url": "https://github.com/igorskyflyer",
+    "twitterHandle": "igorskyflyer",
+    "emailAddress": "support@igorskyflyer.me",
   }
 ]


### PR DESCRIPTION
This PR adds the following ad-block lists:
- [**AdVoid.Full**](https://github.com/the-advoid/ad-void#%EF%B8%8F-advoidfull)
- [**AdVoid.Core**](https://github.com/the-advoid/ad-void#-advoidcore)
- [**AdVoid.DNS**](https://github.com/the-advoid/ad-void#-advoiddns)
- [**AdVoid.Addon.NoAnnoyances**](https://github.com/the-advoid/ad-void#-advoidaddonnoannoyances)
- [**AdVoid.Addon.NoExternals**](https://github.com/the-advoid/ad-void#-advoidaddonnoexternals)
- [**AdVoid.Addon.NoExtras**](https://github.com/the-advoid/ad-void#-advoidaddonnoextras)

<br>

✨ Thank you. 👋🏼