### PR TITLE
Add recruiter-spam-domains by actx4gh

### DIFF
--- a/services/Directory/data/FilterList.json
+++ b/services/Directory/data/FilterList.json
@@ -18753,5 +18753,26 @@
     "issuesUrl": "https://github.com/TantalusDrive/Secfilters/issues",
     "licenseId": 9,
     "name": "IDN Homograph & Favicon Security List - uBlock Origin version"
+  },
+  {
+    "description": "Domains commonly used to send recruiter spam and phishing-style job solicitations.",
+    "homeUrl": "https://github.com/actx4gh/recruiter-spam-domains",
+    "id": 2845,
+    "licenseId": 28,
+    "name": "Recruiter / Job Spam Domains"
+  },
+  {
+    "description": "Adblock-format rules for domains commonly used to send recruiter spam and phishing-style job solicitations.",
+    "homeUrl": "https://github.com/actx4gh/recruiter-spam-domains",
+    "id": 2846,
+    "licenseId": 28,
+    "name": "Recruiter / Job Spam Domains (Adblock)"
+  },
+  {
+    "description": "Hosts-file format for domains commonly used to send recruiter spam and phishing-style job solicitations.",
+    "homeUrl": "https://github.com/actx4gh/recruiter-spam-domains",
+    "id": 2847,
+    "licenseId": 28,
+    "name": "Recruiter / Job Spam Domains (Hosts)"
   }
 ]

--- a/services/Directory/data/FilterListMaintainer.json
+++ b/services/Directory/data/FilterListMaintainer.json
@@ -6478,5 +6478,17 @@
   {
     "filterListId": 2844,
     "maintainerId": 210
+  },
+  {
+    "filterListId": 2845,
+    "maintainerId": 211
+  },
+  {
+    "filterListId": 2846,
+    "maintainerId": 211
+  },
+  {
+    "filterListId": 2847,
+    "maintainerId": 211
   }
 ]

--- a/services/Directory/data/FilterListSyntax.json
+++ b/services/Directory/data/FilterListSyntax.json
@@ -9398,5 +9398,25 @@
   {
     "filterListId": 2844,
     "syntaxId": 4
+  },
+  {
+    "filterListId": 2845,
+    "syntaxId": 2
+  },
+  {
+    "filterListId": 2846,
+    "syntaxId": 3
+  },
+  {
+    "filterListId": 2846,
+    "syntaxId": 4
+  },
+  {
+    "filterListId": 2846,
+    "syntaxId": 6
+  },
+  {
+    "filterListId": 2847,
+    "syntaxId": 1
   }
 ]

--- a/services/Directory/data/FilterListTag.json
+++ b/services/Directory/data/FilterListTag.json
@@ -13418,5 +13418,17 @@
   {
     "filterListId": 2844,
     "tagId": 10
+  },
+  {
+    "filterListId": 2845,
+    "tagId": 7
+  },
+  {
+    "filterListId": 2846,
+    "tagId": 7
+  },
+  {
+    "filterListId": 2847,
+    "tagId": 7
   }
 ]

--- a/services/Directory/data/FilterListViewUrl.json
+++ b/services/Directory/data/FilterListViewUrl.json
@@ -17846,5 +17846,23 @@
     "id": 3245,
     "primariness": 2,
     "url": "https://raw.githubusercontent.com/TantalusDrive/Secfilters/refs/heads/main/Lists/uBlock/IDNHomographFavicon.txt"
+  },
+  {
+    "filterListId": 2845,
+    "id": 3246,
+    "primariness": 1,
+    "url": "https://raw.githubusercontent.com/actx4gh/recruiter-spam-domains/trunk/domains.txt"
+  },
+  {
+    "filterListId": 2846,
+    "id": 3247,
+    "primariness": 1,
+    "url": "https://raw.githubusercontent.com/actx4gh/recruiter-spam-domains/trunk/adblock.txt"
+  },
+  {
+    "filterListId": 2847,
+    "id": 3248,
+    "primariness": 1,
+    "url": "https://raw.githubusercontent.com/actx4gh/recruiter-spam-domains/trunk/hosts.txt"
   }
 ]

--- a/services/Directory/data/Maintainer.json
+++ b/services/Directory/data/Maintainer.json
@@ -1088,5 +1088,10 @@
     "id": 210,
     "name": "TantalusDrive",
     "url": "https://github.com/TantalusDrive"
+  },
+  {
+    "id": 211,
+    "name": "Aaron Colichia",
+    "url": "https://github.com/actx4gh"
   }
 ]


### PR DESCRIPTION
This PR adds the recruiter-spam-domains list by @actx4gh in three formats:
- domains.txt
- adblock.txt
- hosts.txt

Source repo:
https://github.com/actx4gh/recruiter-spam-domains