### PR TITLE
Rename "Stevo's GenAI Blocklist" to "Stevo's AI Blocklist"

### DIFF
--- a/services/Directory/data/FilterList.json
+++ b/services/Directory/data/FilterList.json
@@ -18545,12 +18545,12 @@
     "name": "IDN Homograph & Favicon Security List - uBlock Origin version"
   },
   {
-    "description": "Filter list for website features that use or promote Generative AI.",
-    "homeUrl": "https://github.com/Stevoisiak/Stevos-GenAI-Blocklist",
+    "description": "Filter list for website features and content that uses Generative AI.",
+    "homeUrl": "https://github.com/Stevoisiak/Stevos-AI-Blocklist",
     "id": 2845,
-    "issuesUrl": "https://github.com/Stevoisiak/Stevos-GenAI-Blocklist/issues",
+    "issuesUrl": "https://github.com/Stevoisiak/Stevos-AI-Blocklist/issues",
     "licenseId": 2,
-    "name": "Stevo's GenAI Blocklist"
+    "name": "Stevo's AI Blocklist"
   },
   {
     "description": "Domains commonly used to send recruiter spam and phishing-style job solicitations.",

--- a/services/Directory/data/FilterListViewUrl.json
+++ b/services/Directory/data/FilterListViewUrl.json
@@ -17521,7 +17521,7 @@
     "filterListId": 2845,
     "id": 3246,
     "primariness": 1,
-    "url": "https://raw.githubusercontent.com/Stevoisiak/Stevos-GenAI-Blocklist/refs/heads/main/GenAI-Blocklist.txt"
+    "url": "https://raw.githubusercontent.com/Stevoisiak/Stevos-AI-Blocklist/refs/heads/main/GenAI-Blocklist.txt"
   },
   {
     "filterListId": 2846,


### PR DESCRIPTION
Filter list was renamed. Old URL redirects to the new one, so previous links will still work.