### PR TITLE
Add List: BlackCatOfficial's Blocking Trash Ads (Made in VN) filter

### DIFF
--- a/services/Directory/data/FilterList.json
+++ b/services/Directory/data/FilterList.json
@@ -18674,5 +18674,15 @@
     "licenseId": 4,
     "name": "Turk-AdFilter (Hosts)",
     "submissionUrl": "https://github.com/omerdduran/turk-adfilter/pulls"
+  },
+  {
+    "id": 3500,
+    "name": "BlackCatOfficial's Blocking Trash Ads (Made in VN)",
+    "description": "Specialized ad-blocking filter made by a Vietnamese guy that blocks all ads missed by standard lists.",
+    "homeUrl": "https://github.com/BlackCatOfficialytb/BlackCatOfficial-ubo-filter",
+    "viewUrl": "https://github.com/BlackCatOfficialytb/BlackCatOfficial-ubo-filter/raw/refs/heads/main/filter.txt",
+    "issuesUrl": "https://github.com/BlackCatOfficialytb/BlackCatOfficial-ubo-filter/issues",
+    "licenseId": 2,
+    "syntaxId": 6
   }
 ]

--- a/services/Directory/data/FilterListTag.json
+++ b/services/Directory/data/FilterListTag.json
@@ -13338,5 +13338,9 @@
   {
     "filterListId": 2860,
     "tagId": 16
+  },
+  {
+    "filterListId": 3500,
+    "tagId": 15
   }
 ]


### PR DESCRIPTION
"name": "BlackCatOfficial's Blocking Trash Ads (Made in VN)",
"description": "Specialized ad-blocking filter made by a Vietnamese guy that blocks all ads missed by standard lists."
"homeUrl": "https://github.com/BlackCatOfficialytb/BlackCatOfficial-ubo-filter"
"viewUrl": "https://github.com/BlackCatOfficialytb/BlackCatOfficial-ubo-filter/raw/refs/heads/main/filter.txt"
"issuesUrl": "https://github.com/BlackCatOfficialytb/BlackCatOfficial-ubo-filter/issues"

curently only supports uBO and/or uBOL (or AdGuard maybe) since this has some syntax (specifically the !#include flag) that are only supports by uBO